### PR TITLE
Add missing translation for cookie notice

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -149,6 +149,18 @@
       },
       {
         "type": "text",
+        "id": "cookie_notice_preferences_modal_description_heading",
+        "label": "Description heading",
+        "default": "Your Privacy Choices"
+      },
+      {
+        "type": "textarea",
+        "id": "cookie_notice_preferences_modal_description_body",
+        "label": "Description text",
+        "default": "In this panel you can express some preferences related to the processing of your personal information. If you allow Performance and Analytics cookies, your data may be used for personalization of ads across Google and other platforms. To deny your consent to the specific processing activities described below, switch the toggles to off and confirm you want to save your choices."
+      },
+      {
+        "type": "text",
         "id": "cookie_notice_preferences_modal_essential_cookies_title",
         "label": "Essential cookies title",
         "default": "Strictly Necessary cookies"


### PR DESCRIPTION
## Why

We added some text in the "Manage preferences" section of the cookie notice banner. This PR adds the possibility for the customer to translate those texts.

This PR implements those changes at the theme level.

PR on main repo: https://github.com/booqable/booqable/pull/11127