### PR TITLE
New header for Adore variant

### DIFF
--- a/assets/adore/app.css
+++ b/assets/adore/app.css
@@ -1,0 +1,183 @@
+#section-header .app-mobile .weglot-widget {
+  justify-content: flex-start;
+}
+
+#section-header .app-mobile .weglot-widget__wrapper {
+  border-radius: var(--border-radius-badge);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__wrapper .weglot-widget__label {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown {
+  left: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-badge);
+  box-shadow: 0 0 8px var(--color-border);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up {
+  top: auto;
+  bottom: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down {
+  bottom: auto;
+  top: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown:before,
+#section-header .app-mobile .weglot-widget__dropdown:after {
+  content: "";
+  position: absolute;
+  left: 20px;
+  width: 0px;
+  height: 0px;
+  border-style: solid;
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .app-mobile .weglot-widget__dropdown--up:after {
+  top: 100%;
+  border-width: 10px 10px 0 10px;
+  border-color: var(--background-primary) transparent transparent transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up:before {
+  top: calc(100% + 1px);
+  border-color: var(--color-border) transparent transparent transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .app-mobile .weglot-widget__dropdown--down:after {
+  bottom: 100%;
+  border-width: 0 10px 10px 10px;
+  border-color: transparent transparent var(--background-primary) transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before {
+  bottom: calc(100% + 1px);
+  border-color: transparent transparent var(--color-border) transparent;
+}
+
+#section-header .app-mobile .weglot-widget__item {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__item span {
+  white-space: nowrap;
+}
+
+@media (min-width: 1100px) {
+  #section-header .header__app [data-short-names="true"] {
+    width: auto;
+  }
+
+  #section-header .header__app .weglot-widget__label {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    color: var(--color-primary);
+  }
+
+  #section-header .header__app .weglot-widget__wrapper {
+    border-radius: var(--border-radius-badge);
+    padding: 0;
+    border: none;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown {
+    left: 50%;
+    transform: translate(-50%, 0);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-badge);
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    background-color: var(--background-primary) !important;
+    box-shadow: 0 0 8px var(--color-border);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up,
+  #section-header .header__app .weglot-widget__dropdown--down {
+    top: calc(100% + 11px);
+    bottom: auto;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown:before,
+  #section-header .header__app .weglot-widget__dropdown:after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 0px;
+    height: 0px;
+    border-style: solid;
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before,
+  #section-header .header__app .weglot-widget__dropdown--up:after,
+  #section-header .header__app .weglot-widget__dropdown--down:before,
+  #section-header .header__app .weglot-widget__dropdown--down:after {
+    bottom: 100%;
+    border-width: 0 10px 10px 10px;
+    border-color: transparent transparent var(--background-primary) transparent;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before,
+  #section-header .header__app .weglot-widget__dropdown--down:before {
+    bottom: calc(100% + 1px);
+    border-color: transparent transparent var(--color-border) transparent;
+  }
+
+  #section-header .header__app .weglot-widget__item {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    color: var(--color-primary);
+    padding: 5px 8px;
+  }
+
+}
+
+@media (hover: hover) {
+  #section-header .app-mobile .weglot-widget__wrapper:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown--up:hover:before {
+    border-color: var(--color-outline) transparent transparent transparent;
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline) transparent;
+  }
+
+  #section-header .app-mobile .weglot-widget__item:hover {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__item:hover {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:hover:before,
+  #section-header .header__app .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline) transparent;
+  }
+}

--- a/assets/adore/header.css
+++ b/assets/adore/header.css
@@ -94,9 +94,7 @@
 }
 
 .header__content-inner .header__cart:last-child,
-.header__content-inner .header__search:last-child,
-.header__content-inner.header__mobile-menu-opener-left .header__cart:nth-last-child(2),
-.header__content-inner.header__mobile-menu-opener-left .header__search:nth-last-child(2) {
+.header__content-inner.header__mobile-menu-opener-left .header__cart:nth-last-child(2) {
   margin-right: -7px;
 }
 
@@ -120,28 +118,6 @@
   padding-right: 10px;
 }
 
-.header__mobile-menu-opener-left .header__search-wrapper {
-  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm) - 7px));
-}
-
-.header__mobile-menu-opener-left .header__search:nth-last-child(2) .header__search-wrapper {
-  right: 7px;
-}
-
-.loaded .header__search-wrapper {
-  display: block !important;
-}
-
-.preview-bar__container ~ .header-sticky .header__search-wrapper {
-  top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
-}
-
-.touch[data-orientation='landscape'] .header__search-wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .header__search-wrapper {
-  right: 0;
-  min-width: 500px;
-}
-
 header:has(.app-mobile) .header__app:has(.app-desktop) {
   display: none;
 }
@@ -154,12 +130,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 @media (min-height: 576px) {
   body:has(.header-sticky) div[data-tippy-root]:has([data-tid="Mini cart"])  {
     top: calc(var(--top-bar-height, 0px) + 24px + 48px) !important;
-  }
-}
-
-@media (min-width: 768px) {
-  .header__search-wrapper {
-    min-width: 600px;
   }
 }
 

--- a/assets/adore/header.css
+++ b/assets/adore/header.css
@@ -1,0 +1,352 @@
+.header {
+  position: relative;
+  z-index: 1001;
+  margin-top: var(--preview-height, 0px) !important;
+  width: 100%;
+}
+
+.header-sticky {
+  position: fixed;
+  top: var(--header-transform, 0px);
+  left: 0;
+  right: 0;
+	transition: top var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+.header__content {
+  color: var(--color-primary);
+  background: var(--background-primary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.header__content--padding-top {
+  padding-top: var(--padding-top-mobile);
+}
+
+.header__content--padding-bottom {
+  padding-bottom: var(--padding-bottom-mobile);
+}
+
+.header__logo-wrapper {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  grid-area: logo;
+}
+
+.header__logo-wrapper:not(:last-child) {
+  padding-right: 16px;
+}
+
+.header__logo-text {
+  font-size: 24px;
+  line-height: var(--font-height-md);
+  font-weight: var(--font-weight-semibold);
+  margin: 0;
+  color: currentColor;
+}
+
+.header__logo-image {
+  max-height: 64px;
+  max-width: 100%;
+}
+
+.header__search {
+  grid-area: search;
+}
+
+.header__cart {
+  min-width: 25px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  grid-area: cart;
+}
+
+.header__cart .fa-spinner-third {
+  color: var(--color-primary);
+}
+
+.header__menu {
+  grid-area: menu;
+}
+
+.header__content-inner {
+  gap: 0px 8px;
+  display: grid;
+  align-items: center;
+  grid-template-columns: 1fr max-content max-content max-content;
+  grid-template-areas:
+    "logo search cart menu";
+}
+
+.header__mobile-menu-opener-left {
+  grid-template-columns: max-content 1fr max-content max-content;
+  grid-template-areas:
+    "menu logo search cart";
+}
+
+.header__content-inner > .header__support,
+.header__content-inner > .header__menu-third {
+  display: none;
+}
+
+.header__content-inner .header__cart:last-child,
+.header__content-inner .header__search:last-child,
+.header__content-inner.header__mobile-menu-opener-left .header__cart:nth-last-child(2),
+.header__content-inner.header__mobile-menu-opener-left .header__search:nth-last-child(2) {
+  margin-right: -7px;
+}
+
+.header__mobile-menu-opener-left .header__logo-wrapper {
+  justify-content: center;
+}
+
+.header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__menu) {
+  padding-left: 10px;
+  padding-right: calc(var(--header-icon-width) + var(--header-gap-sm) + 10px);
+}
+
+.header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search),
+.header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__cart) {
+  padding-left: 11px;
+  padding-right: 10px;
+}
+
+.header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search + .header__cart) {
+  padding-left: calc(var(--header-icon-width) + var(--header-gap-sm) + 3px);
+  padding-right: 10px;
+}
+
+.header__mobile-menu-opener-left .header__search-wrapper {
+  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm) - 7px));
+}
+
+.header__mobile-menu-opener-left .header__search:nth-last-child(2) .header__search-wrapper {
+  right: 7px;
+}
+
+.loaded .header__search-wrapper {
+  display: block !important;
+}
+
+.preview-bar__container ~ .header-sticky .header__search-wrapper {
+  top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
+}
+
+.touch[data-orientation='landscape'] .header__search-wrapper,
+.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .header__search-wrapper {
+  right: 0;
+  min-width: 500px;
+}
+
+header:has(.app-mobile) .header__app:has(.app-desktop) {
+  display: none;
+}
+
+.header__app:has(.app-mobile) {
+  display: block;
+  padding: 20px 0 50px;
+}
+
+@media (min-height: 576px) {
+  body:has(.header-sticky) div[data-tippy-root]:has([data-tid="Mini cart"])  {
+    top: calc(var(--top-bar-height, 0px) + 24px + 48px) !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .header__search-wrapper {
+    min-width: 600px;
+  }
+}
+
+@media (min-width: 1100px) {
+  .header__inner:has(.header__menu),
+  .header__inner:has(.header__menu-second),
+  .header__inner:has(.header__menu-third) {
+    position: relative;
+  }
+
+  .header__inner:has(.header__menu):after,
+  .header__inner:has(.header__menu-second):after,
+  .header__inner:has(.header__menu-third):after {
+    --header-icon-height: 48px;
+
+    content: "";
+    position: absolute;
+    bottom: calc(var(--padding-bottom) + var(--header-icon-height) + var(--padding-top));
+    left: 0;
+    height: 1px;
+    width: 100%;
+    background: var(--color-border);
+    transform: translate(0, 50%);
+  }
+
+  .header__inner:has(.header__menu-second):not(:has(.header__menu)):after,
+  .header__inner:has(.header__menu-third):not(:has(.header__menu:last-child)):after {
+    --header-icon-height: 18px;
+  }
+
+  .header__content {
+    --menus-gap-y: calc(var(--padding-top) + var(--padding-bottom));
+  }
+
+  .header__content--padding-top {
+    padding-top: var(--padding-top);
+  }
+
+  .header__content--padding-bottom {
+    padding-bottom: var(--padding-bottom);
+  }
+
+  .header__content-inner {
+    gap: 0px var(--header-gap-md);
+    display: grid;
+    grid-template-columns: max-content 1fr max-content max-content max-content;
+    grid-template-areas: none;
+    grid-template-rows: auto auto;
+  }
+
+  .header__logo-wrapper,
+  .header__mobile-menu-opener-left .header__logo-wrapper {
+    justify-content: flex-start;
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .header__logo-wrapper:has(+ .header__search),
+  .header__logo-wrapper:has(+ .header__cart),
+  .header__logo-wrapper:has(+ .header__search + .header__cart),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__cart),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search + .header__cart) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .header__cart,
+  .header__mobile-menu-opener-left .header__cart {
+    grid-column: 5;
+    grid-row: 1;
+  }
+
+  .header__content-inner.header__mobile-menu-opener-right .header__cart:nth-last-child(2) {
+    margin-right: -7px;
+  }
+
+  .header__menu,
+  .header__mobile-menu-opener-left .header__menu {
+    grid-column: 1;
+    grid-row: 2;
+    display: inline-flex;
+    justify-content: flex-start;
+    margin-top: var(--menus-gap-y);
+    padding-right: clamp(16px, 2.2vw, 50px);
+  }
+
+  .header__menu-secondary {
+    grid-column: 1 / span 2;
+    grid-row: 2;
+    margin-top: var(--padding-top);
+  }
+
+  .header__content-inner:has(.header__menu) .header__menu-secondary {
+    grid-column: 2;
+  }
+
+  .header__content-inner:not(:has(.header__cart)):not(:has(.header__support)):not(:has(.header__app)) .header__menu-secondary {
+    grid-column: 2 / span 4;
+  }
+
+  .header__content-inner:not(:has(.header__menu)):not(:has(.header__cart)):not(:has(.header__support)):not(:has(.header__app)) .header__menu-secondary {
+    grid-column: 1 / span 5;
+  }
+
+  .header__search,
+  .header__mobile-menu-opener-left .header__search {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .header__menu-third,
+  .header__mobile-menu-opener-left .header__menu-third {
+    grid-column: 3 / span 3;
+    grid-row: 2;
+    margin-top: var(--menus-gap-y);
+  }
+
+  .header__content-inner:not(:has(.header__cart)):not(:has(.header__support)):not(:has(.header__app)) .header__menu-third,
+  .header__mobile-menu-opener-left:not(:has(.header__cart)):not(:has(.header__support)):not(:has(.header__app)) .header__menu-third {
+    grid-row: 1;
+    margin: 0 0 0 16px;
+  }
+
+  .header__support,
+  .header__mobile-menu-opener-left .header__support {
+    grid-column: 4;
+    grid-row: 1;
+  }
+
+  .header__content-inner:not(:has(.header__cart)) .header__support,
+  .header__mobile-menu-opener-left:not(:has(.header__cart)) .header__support {
+    grid-column: 5;
+    justify-content: flex-end;
+  }
+
+  .header__content-inner:not(:has(.header__cart)) .header__support-wrapper:not(:has(.header__support-opener)),
+  .header__mobile-menu-opener-left:not(:has(.header__cart)) .header__support-wrapper:not(:has(.header__support-opener)) {
+    text-align: right;
+  }
+
+  .header__menu .header__support {
+    display: none;
+  }
+
+  .header__content-inner > .header__support,
+  .header__content-inner > .header__menu-third {
+    display: block;
+  }
+
+  .header__app:has(.app-desktop) {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .header__app:has(.app-mobile) {
+    display: none;
+  }
+
+  header:has(.app-mobile) .header__app:has(.app-desktop) {
+    display: block;
+  }
+
+  .header__content-inner:has(.header__cart):not(:has(.header__support)) .header__app,
+  .header__content-inner:has(.header__support):not(:has(.header__cart)) .header__app,
+  .header__mobile-menu-opener-left:has(.header__cart):not(:has(.header__support)) .header__app,
+  .header__mobile-menu-opener-left:has(.header__support):not(:has(.header__cart)) .header__app {
+    grid-column: 4;
+  }
+
+  .header__content-inner:not(:has(.header__cart)):not(:has(.header__support)) .header__app,
+  .header__mobile-menu-opener-left:not(:has(.header__cart)):not(:has(.header__support)) .header__app {
+    grid-column: 5;
+  }
+}
+
+@media (min-width: 1200px) {
+  .header__content-inner {
+    gap: 0px var(--header-gap-lg);
+  }
+
+  .header__logo-wrapper:has(+ .header__search),
+  .header__logo-wrapper:has(+ .header__cart),
+  .header__logo-wrapper:has(+ .header__search + .header__cart),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__cart),
+  .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search + .header__cart) {
+    padding-right: 22px;
+  }
+}

--- a/assets/adore/menu.css
+++ b/assets/adore/menu.css
@@ -108,7 +108,7 @@
 .menu__nav {
   position: var(--menu-nav-position);
   top: var(--menu-nav-position-top);
-  right: 0;
+  left: 0;
   width: var(--menu-nav-width);
   height: var(--menu-nav-height);
   font-size: calc(var(--font-size-regular) + 2px);
@@ -311,12 +311,16 @@
   height: calc(100dvh - var(--header-height, 110px) + var(--top-bar-height, 0px) + 1px);
 }
 
-.extra-menu {
+.menu-secondary {
+  display: none;
+}
+
+.menu-third {
   padding-bottom: var(--extra-menu-padding);
   font-size: var(--extra-menu-font-size);
 }
 
-.extra-menu__link {
+.menu-third__link {
   padding: 12px 0;
 }
 
@@ -338,8 +342,8 @@
   margin-right: 15px;
 }
 
-@media (min-width: 992px) {
-  body:has(.extra-menu) .extra-menu {
+@media (min-width: 1100px) {
+  body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 8px;
   }
 
@@ -371,12 +375,27 @@
     --menu-nav-background: none;
     --menu-nav-height: auto;
     --menu-nav-position: absolute;
-    --menu-nav-position-top: calc((var(--header-height) - var(--top-bar-height, 0px) - var(--preview-height, 0px)) / 2 + var(--header-icon-height) / 2);
+    --menu-nav-position-top: calc(var(--header-icon-height) + var(--padding-bottom));
     --menu-nav-position-top-sticky-header: var(--menu-nav-position-top);
     --menu-nav-transform: translate(0, 0);
     --menu-nav-width: auto;
 
     position: relative;
+  }
+
+  .menu-secondary:has(~ .menu) ~ .menu {
+    position: relative;
+  }
+
+  .menu-secondary:has(~ .menu) ~ .menu:after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translate(0, -50%);
+    height: 60px;
+    width: 1px;
+    background: var(--color-border);
   }
 
   .menu__opener {
@@ -426,15 +445,16 @@
 
   .menu__item {
     padding: 11px 19px;
-    border-bottom: 1px solid var(--color-border);
+    border-top: 1px solid var(--color-border);
   }
 
   .menu__item--desktop-hidden {
     display: none;
   }
 
-  .menu__item:last-child {
-    border-bottom: none;
+  .menu__item:first-child,
+  .menu__item--desktop-hidden:first-of-type {
+    border-top: none;
   }
 
   .menu__dropdown-opener {
@@ -557,24 +577,216 @@
   }
 
   .menu__message,
-  .menu__nav .extra-menu {
+  .menu__nav .menu-third {
     display: none;
   }
 
-  .extra-menu__list {
+  .menu-third__list {
     display: flex;
     align-items: center;
     justify-content: flex-end;
     margin: 0 calc(-1 * var(--extra-menu-item-indent));
   }
 
-  .extra-menu__item {
+  .menu-third__item {
     padding: 0 var(--extra-menu-item-indent);
+  }
+
+  .menu-third__link {
+    padding: 0;
+  }
+
+  .menu-secondary {
+    --menu-item-indent: calc(var(--padding-top) + 1px);
+
+    display: block;
+  }
+
+  .menu-secondary:has(~ .menu) .menu-secondary__list {
+    --menu-item-indent: calc(var(--padding-top) * 1.5 + 1px);
+  }
+
+  .menu-secondary__list {
+    padding: var(--menu-item-indent) 0 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .menu-secondary__item {
+    margin: 0 clamp(8px, 1.3vw, 30px) calc(-1 * var(--padding-bottom)) 0;
+    display: flex;
+    align-items: center;
+    flex-direction: row-reverse;
+    padding: 0 clamp(8px, 0.7vw, 16px) var(--menu-item-indent);
+  }
+
+  .menu-secondary:has(~ .menu) .menu-secondary__item {
+    --menu-item-indent: calc(var(--padding-top) * 1.5 + 1px);
+
+    min-height: var(--header-icon-height);
+  }
+
+  .menu-secondary__item:last-child {
+    margin-right: 0;
+  }
+
+  .menu-secondary__item-icon {
+    margin-left: 12px;
+  }
+
+  .menu-secondary__item-icon svg {
+    transform: rotate(0);
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  .menu-secondary__item-icon path {
+    fill: var(--color-primary);
+    stroke: var(--color-primary);
+    stroke-width: 1px;
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  .menu-secondary__item > .menu-secondary__link {
+    padding: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: var(--font-height-xs);
+    font-size: calc(var(--font-size-regular) + 2px);
+    font-weight: var(--font-weight-bold);
+  }
+
+  .menu-secondary__item.has-dropdown > .menu-secondary__link {
+    padding-right: 23px;
+  }
+
+  .menu-secondary__item.has-dropdown > .menu-secondary__dropdown-opener {
+    margin-left: -22px;
+  }
+
+  .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon svg {
+    transform: rotate(180deg);
+  }
+
+  .menu-secondary__dropdown-opener {
+    width: auto;
+    height: auto;
+    pointer-events: none;
+    margin: 0;
+  }
+
+  .menu-secondary__dropdown {
+    position: absolute;
+    pointer-events: none;
+    top: 100%;
+    left: 0;
+    z-index: -1;
+    width: 100vw;
+    background: none;
+  }
+
+  .menu-secondary__dropdown-wrapper {
+    background: var(--background-primary);
+    transform: translateY(-100%);
+    transition: transform var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  .menu-secondary__dropdown-wrapper:after {
+    content: "";
+    position: absolute;
+    bottom: 1px;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--color-border);
+  }
+
+  .menu-secondary__item:hover > .menu-secondary__dropdown {
+    pointer-events: all;
+  }
+
+  .menu-secondary__item:hover > .menu-secondary__dropdown .menu-secondary__dropdown-wrapper {
+    transform: translate(0, 0);
+  }
+
+  .menu-secondary__item:hover > .menu-secondary__dropdown .menu-secondary__dropdown-wrapper:after {
+    bottom: 0;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown-opener,
+  .menu-secondary__dropdown-title {
+    display: none;
+  }
+
+  .menu-secondary__dropdown-list {
+    max-width: var(--max-width);
+    max-height: calc(100dvh - var(--header-height, 242px));
+    padding: 25px var(--horizontal-padding);
+    margin: 0 auto;
+    overflow-y: auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
+    align-items: flex-start;
+  }
+
+  .menu-secondary__dropdown-link {
+    font-size: calc(var(--font-size-regular) + 4px);
+    font-weight: var(--font-weight-regular);
+    padding: 0;
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown,
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-wrapper {
+    position: static;
+    height: auto;
+    width: auto;
+    max-width: none;
+    pointer-events: all;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-wrapper:after {
+    display: none;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-wrapper {
+    transform: translate(0, 0);
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-list {
+    padding: 16px 0;
+    border: none;
+    display: block;
+    width: 100%;
+    max-height: auto;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-item {
+    display: block;
+    padding: 0 0 10px;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-item:last-child {
+    padding-bottom: 0;
+  }
+
+  .menu-secondary__dropdown .menu-secondary__dropdown .menu-secondary__dropdown-link {
+    font-size: calc(var(--font-size-regular) - 2px);
+  }
+
+  .menu-secondary__dropdown-item:has(.menu-secondary__dropdown) .menu-secondary__dropdown-link {
+    padding-right: 0;
+  }
+
+  .loaded .menu-secondary__dropdown {
+    display: block !important;
   }
 }
 
 @media (min-width: 1200px) {
-  body:has(.extra-menu) .extra-menu {
+  body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
   }
 
@@ -601,9 +813,18 @@
   .menu__dropdown-item:hover > .menu__dropdown-link {
     color: var(--color-outline);
   }
+
+  .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) + .menu-secondary__link {
+    color: var(--color-outline);
+  }
+
+  .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
+    fill: var(--color-outline);
+    stroke: var(--color-outline);
+  }
 }
 
-@media (max-width: 991px) {
+@media (max-width: 1099px) {
   .menu__opener {
     background: none;
     border-color: var(--color-border);

--- a/assets/adore/search-form.css
+++ b/assets/adore/search-form.css
@@ -1,0 +1,283 @@
+.header__search {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
+.header__search-opener {
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--header-icon-width);
+  height: var(--header-icon-height);
+}
+
+.header__search-opener svg {
+  pointer-events: none;
+  width: 25px;
+}
+
+.header__search-opener g {
+  stroke: var(--color-primary);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+.header__search-submit {
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 42px;
+  height: 100%;
+  transform: translateY(-50%);
+  z-index: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+}
+
+.header__search-label {
+  display: none;
+}
+
+.header__search-submit g {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  stroke: var(--color-primary);
+}
+
+.header__search-icon {
+  font-size: 20px;
+  width: 25px;
+  height: 25px;
+}
+
+.header__search-icon g {
+  stroke: var(--color-primary);
+}
+
+.header__search-input {
+  min-width: 230px;
+  width: 100%;
+  height: 48px;
+  padding: 11px 50px;
+  font-size: 16px;
+  line-height: var(--font-height-sm);
+  border-radius: var(--border-radius-button);
+  border: 1px solid var(--color-border);
+  background: var(--background-primary);
+  color: var(--color-primary);
+}
+
+.header__search-input::placeholder {
+  color: var(--color-secondary);
+}
+
+.header__search-input:focus {
+  outline: none;
+  border-color: var(--color-outline);
+}
+
+.header__search-input::-webkit-search-cancel-button {
+  display: none !important;
+}
+
+.header__search-input::-webkit-search-decoration {
+  display: none;
+}
+
+.header__search-reset {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  height: 100%;
+  width: 40px;
+  transform: translate(0, -50%);
+  display: flex;
+  align-items: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.header__search-reset:after,
+.header__search-reset:before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 45%;
+  height: 2px;
+  width: 18px;
+  background: var(--color-primary);
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition: background var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+.header__search-reset:before {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.header__search-wrapper {
+  position: absolute;
+  top: calc((var(--header-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
+  right: calc(-2 * (var(--header-icon-width) + var(--header-gap-sm)));
+	min-width: calc(100vw - var(--horizontal-padding-mobile) * 2);
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  visibility: hidden;
+	opacity: 0;
+	transition-duration: var(--animation-duration);
+	transition-timing-function: var(--transition-function-ease-in-out);
+	transition-property: visibility, opacity;
+  display: block !important;
+}
+
+.header__search:last-child .header__search-wrapper {
+  right: 7px;
+}
+
+.header__search:nth-last-child(2) .header__search-wrapper {
+  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm)) + 7px);
+}
+
+.header__search:nth-last-child(2):has(+ .header__menu) .header__search-wrapper {
+  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm)));
+}
+
+.header__search-input-wrapper.filled .header__search-reset,
+.header__search #search-opener:checked ~ .header__search-wrapper {
+  visibility: visible;
+  pointer-events: all;
+  opacity: 1;
+}
+
+.header__search #search-opener:checked ~ .header__search-opener g {
+  stroke: var(--color-outline);
+}
+
+@media (min-width: 1100px) {
+  .header__search,
+  .header__mobile-menu-opener-left .header__search {
+    justify-content: flex-end;
+    grid-column: 2;
+    grid-row: 1;
+    container: search / inline-size;
+  }
+
+  .header__content-inner.header__mobile-menu-opener-right .header__search:nth-last-child(2) {
+    margin-right: -7px;
+  }
+
+  .header__search-wrapper {
+    min-width: 350px;
+    max-width: 560px;
+    width: 100%;
+    margin: 0 auto;
+    top: calc((var(--header-height) - var(--top-bar-height, 0px) + var(--header-icon-height)) / 2);
+  }
+
+  .header__search-wrapper,
+  .header__search:last-child .header__search-wrapper,
+  .header__search:nth-last-child(2) .header__search-wrapper,
+  .header__search:nth-last-child(2):has(+ .header__menu) .header__search-wrapper,
+  .header__mobile-menu-opener-left .header__search-wrapper,
+  .header__mobile-menu-opener-left .header__search:nth-last-child(2) .header__search-wrapper {
+    right: 0;
+  }
+
+  .header__search-submit:has(.header__search-label) {
+    width: auto;
+    height: calc(100% - 8px);
+  }
+
+  .header__search-submit:has(.header__search-label) .header__search-icon {
+    display: none;
+  }
+
+  .header__search-submit:has(.header__search-label) .header__search-label {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    height: 100%;
+    padding: 5px 20px;
+    margin: 0;
+    line-height: 1;
+  }
+}
+
+@media (min-width: 1300px) {
+  .header__content-inner .header__search:last-child,
+  .header__content-inner.header__mobile-menu-opener-left .header__search:nth-last-child(2),
+  .header__content-inner.header__mobile-menu-opener-right .header__search:nth-last-child(2) {
+    margin-right: 0;
+  }
+}
+
+@container (min-width: 350px) {
+  .header__search-opener {
+    display: none;
+  }
+
+  .header__search-wrapper {
+    transition: none;
+    visibility: visible;
+    opacity: 1;
+    pointer-events: all;
+    position: relative;
+    top: 0;
+  }
+
+  .preview-bar__container ~ .header-sticky .header__search-wrapper {
+    top: 0;
+  }
+
+  .header__search-input {
+    padding-left: 11px;
+  }
+
+  .header__search-input-wrapper.filled .header__search-input {
+    padding-right: 85px;
+  }
+
+  .header__search-input-wrapper.filled:has(.header__search-label) .header__search-input {
+    padding-right: 150px;
+  }
+
+  .header__search-submit {
+    left: auto;
+    right: 2px;
+  }
+
+  .header__search-submit:has(.header__search-label) {
+    right: 4px;
+  }
+
+  .header__search-reset {
+    right: 50px;
+    width: 20px;
+  }
+
+  .header__search-input-wrapper.filled:has(.header__search-label) .header__search-reset {
+    right: 124px;
+  }
+}
+
+@media (hover: hover) {
+  .header__search-opener:hover g,
+  .header__search-submit:hover g,
+  .header__search-icon:hover g {
+    stroke: var(--color-outline);
+  }
+
+  .header__search-reset:hover:after,
+  .header__search-reset:hover:before {
+    background: var(--color-outline);
+  }
+}

--- a/assets/adore/support.css
+++ b/assets/adore/support.css
@@ -1,0 +1,89 @@
+.support {
+  --support-justify-content: flex-start;
+  --support-item-padding: 0 0 16px;
+  --support-dropdown-padding: 0 0 40px;
+  --support-opener-displaying: none;
+  --support-dropdown-position: static;
+  --support-dropdown-events: all;
+  --support-dropdown-opacity: 1;
+  --support-dropdown-visibility: visible;
+  --support-dropdown-border: none;
+  --support-dropdown-border-radius: 0;
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: var(--support-justify-content);
+}
+
+.support__opener {
+  display: var(--support-opener-displaying);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  cursor: pointer;
+}
+
+.support__opener .icon {
+  font-size: 22px;
+}
+
+.support__icon {
+  margin-right: 8px;
+  color: var(--color-outline);
+}
+
+.support__wrapper {
+  padding: var(--support-dropdown-padding);
+  transition-duration: var(--animation-duration);
+  transition-timing-function: var(--transition-function-ease-in-out);
+  transition-property: visibility, opacity;
+}
+
+.support:has(.support__opener) .support__wrapper {
+  position: var(--support-dropdown-position);
+  top: calc(100% + 8px);
+  right: 0;
+  pointer-events: var(--support-dropdown-events);
+  visibility: var(--support-dropdown-visibility);
+  opacity: var(--support-dropdown-opacity);
+  z-index: 1;
+  background: var(--background-primary);
+  border: var(--support-dropdown-border);
+  border-radius: var(--support-dropdown-border-radius);
+  padding: var(--support-dropdown-padding);
+}
+
+.support:has(.support__opener) .support__item:not(:empty) {
+  padding: var(--support-item-padding);
+  white-space: nowrap;
+}
+
+.support #support-opener:checked ~ .support__wrapper {
+  visibility: visible;
+  pointer-events: all;
+  opacity: 1;
+}
+
+.loaded .support__wrapper {
+  display: block !important;
+}
+
+@media (min-width: 1100px) {
+  .support {
+    --support-justify-content: center;
+    --support-dropdown-padding: 16px;
+    --support-dropdown-position: absolute;
+    --support-item-padding: 8px;
+    --support-opener-displaying: block;
+    --support-dropdown-events: none;
+    --support-dropdown-opacity: 0;
+    --support-dropdown-visibility: hidden;
+    --support-dropdown-border: 1px solid var(--color-border);
+    --support-dropdown-border-radius: var(--border-radius-block);
+  }
+}
+
+@media (hover: hover) {
+  .support__opener:hover {
+    color: var(--color-outline);
+  }
+}

--- a/assets/app.css
+++ b/assets/app.css
@@ -1,0 +1,183 @@
+#section-header .app-mobile .weglot-widget {
+  justify-content: flex-start;
+}
+
+#section-header .app-mobile .weglot-widget__wrapper {
+  border-radius: var(--border-radius-badge);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__wrapper .weglot-widget__label {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown {
+  left: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-badge);
+  box-shadow: 0 0 8px var(--color-border);
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up {
+  top: auto;
+  bottom: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down {
+  bottom: auto;
+  top: calc(100% + 11px);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown:before,
+#section-header .app-mobile .weglot-widget__dropdown:after {
+  content: "";
+  position: absolute;
+  left: 20px;
+  width: 0px;
+  height: 0px;
+  border-style: solid;
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up:before,
+#section-header .app-mobile .weglot-widget__dropdown--up:after {
+  top: 100%;
+  border-width: 10px 10px 0 10px;
+  border-color: var(--background-primary) transparent transparent transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--up:before {
+  top: calc(100% + 1px);
+  border-color: var(--color-border) transparent transparent transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before,
+#section-header .app-mobile .weglot-widget__dropdown--down:after {
+  bottom: 100%;
+  border-width: 0 10px 10px 10px;
+  border-color: transparent transparent var(--background-primary) transparent;
+}
+
+#section-header .app-mobile .weglot-widget__dropdown--down:before {
+  bottom: calc(100% + 1px);
+  border-color: transparent transparent var(--color-border) transparent;
+}
+
+#section-header .app-mobile .weglot-widget__item {
+  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+}
+
+#section-header .app-mobile .weglot-widget__item span {
+  white-space: nowrap;
+}
+
+@media (min-width: 992px) {
+  #section-header .header__app [data-short-names="true"] {
+    width: auto;
+  }
+
+  #section-header .header__app .weglot-widget__label {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    color: var(--color-primary);
+  }
+
+  #section-header .header__app .weglot-widget__wrapper {
+    border-radius: var(--border-radius-badge);
+    padding: 0;
+    border: none;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown {
+    left: 50%;
+    transform: translate(-50%, 0);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-badge);
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    background-color: var(--background-primary) !important;
+    box-shadow: 0 0 8px var(--color-border);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up,
+  #section-header .header__app .weglot-widget__dropdown--down {
+    top: calc(100% + 11px);
+    bottom: auto;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown:before,
+  #section-header .header__app .weglot-widget__dropdown:after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 0px;
+    height: 0px;
+    border-style: solid;
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before,
+  #section-header .header__app .weglot-widget__dropdown--up:after,
+  #section-header .header__app .weglot-widget__dropdown--down:before,
+  #section-header .header__app .weglot-widget__dropdown--down:after {
+    bottom: 100%;
+    border-width: 0 10px 10px 10px;
+    border-color: transparent transparent var(--background-primary) transparent;
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:before,
+  #section-header .header__app .weglot-widget__dropdown--down:before {
+    bottom: calc(100% + 1px);
+    border-color: transparent transparent var(--color-border) transparent;
+  }
+
+  #section-header .header__app .weglot-widget__item {
+    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
+    color: var(--color-primary);
+    padding: 5px 8px;
+  }
+
+}
+
+@media (hover: hover) {
+  #section-header .app-mobile .weglot-widget__wrapper:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown--up:hover:before {
+    border-color: var(--color-outline) transparent transparent transparent;
+  }
+
+  #section-header .app-mobile .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline) transparent;
+  }
+
+  #section-header .app-mobile .weglot-widget__item:hover {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__item:hover {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
+    color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown:hover {
+    border-color: var(--color-outline);
+  }
+
+  #section-header .header__app .weglot-widget__dropdown--up:hover:before,
+  #section-header .header__app .weglot-widget__dropdown--down:hover:before {
+    border-color: transparent transparent var(--color-outline) transparent;
+  }
+}

--- a/assets/header.css
+++ b/assets/header.css
@@ -53,166 +53,6 @@
   max-width: 100%;
 }
 
-.header__search {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-}
-
-.header__search-opener {
-  color: inherit;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--header-icon-width);
-  height: var(--header-icon-height);
-}
-
-.header__search-opener svg {
-  pointer-events: none;
-  width: 25px;
-}
-
-.header__search-opener g {
-  stroke: var(--color-primary);
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-.header__search-submit {
-  position: absolute;
-  top: 50%;
-  left: 2px;
-  width: 42px;
-  height: 100%;
-  transform: translateY(-50%);
-  z-index: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-}
-
-.header__search-submit g {
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-  stroke: var(--color-primary);
-}
-
-.header__search-icon {
-  font-size: 20px;
-  width: 25px;
-  height: 25px;
-}
-
-.header__search-icon g {
-  stroke: var(--color-primary);
-}
-
-.header__search-input {
-  min-width: 230px;
-  width: 100%;
-  height: 48px;
-  padding: 11px 50px;
-  font-size: 16px;
-  line-height: var(--font-height-sm);
-  border-radius: var(--border-radius-button);
-  border: 1px solid var(--color-border);
-  background: var(--background-primary);
-  color: var(--color-primary);
-}
-
-.header__search-input::placeholder {
-  color: var(--color-secondary);
-}
-
-.header__search-input:focus {
-  outline: none;
-  border-color: var(--color-outline);
-}
-
-.header__search-input::-webkit-search-cancel-button {
-  display: none !important;
-}
-
-.header__search-input::-webkit-search-decoration {
-  display: none;
-}
-
-.header__search-reset {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  height: 100%;
-  width: 40px;
-  transform: translate(0, -50%);
-  display: flex;
-  align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  opacity: 0;
-  visibility: hidden;
-}
-
-.header__search-reset:after,
-.header__search-reset:before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 45%;
-  height: 2px;
-  width: 18px;
-  background: var(--color-primary);
-  transform: translate(-50%, -50%) rotate(45deg);
-  transition: background var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-.header__search-reset:before {
-  transform: translate(-50%, -50%) rotate(-45deg);
-}
-
-.header__search-wrapper {
-  position: absolute;
-  top: calc((var(--header-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
-  right: calc(-2 * (var(--header-icon-width) + var(--header-gap-sm)));
-	min-width: calc(100vw - var(--horizontal-padding-mobile) * 2);
-  padding: 0;
-  margin: 0;
-  pointer-events: none;
-  visibility: hidden;
-	opacity: 0;
-	transition-duration: var(--animation-duration);
-	transition-timing-function: var(--transition-function-ease-in-out);
-	transition-property: visibility, opacity;
-  display: block !important;
-}
-
-.header__search:last-child .header__search-wrapper {
-  right: 7px;
-}
-
-.header__search:nth-last-child(2) .header__search-wrapper {
-  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm)) + 7px);
-}
-
-.header__search:nth-last-child(2):has(+ .header__menu) .header__search-wrapper {
-  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm)));
-}
-
-.header__search-input-wrapper.filled .header__search-reset,
-.header__search #search-opener:checked ~ .header__search-wrapper {
-  visibility: visible;
-  pointer-events: all;
-  opacity: 1;
-}
-
-.header__search #search-opener:checked ~ .header__search-opener g {
-  stroke: var(--color-outline);
-}
-
 .header__cart {
   min-width: 25px;
   display: flex;
@@ -235,9 +75,7 @@
 }
 
 .header__content-inner .header__cart:last-child,
-.header__content-inner .header__search:last-child,
-.header__content-inner.header__mobile-menu-opener-left .header__cart:nth-last-child(2),
-.header__content-inner.header__mobile-menu-opener-left .header__search:nth-last-child(2) {
+.header__content-inner.header__mobile-menu-opener-left .header__cart:nth-last-child(2) {
   margin-right: -7px;
 }
 
@@ -270,30 +108,8 @@
   order: 4;
 }
 
-.header__mobile-menu-opener-left .header__search-wrapper {
-  right: calc(-1 * (var(--header-icon-width) + var(--header-gap-sm) - 7px));
-}
-
-.header__mobile-menu-opener-left .header__search:nth-last-child(2) .header__search-wrapper {
-  right: 7px;
-}
-
 .header__mobile-menu-opener-left .header__cart {
   order: 5;
-}
-
-.loaded .header__search-wrapper {
-  display: block !important;
-}
-
-.preview-bar__container ~ .header-sticky .header__search-wrapper {
-  top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
-}
-
-.touch[data-orientation='landscape'] .header__search-wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .header__search-wrapper {
-  right: 0;
-  min-width: 500px;
 }
 
 header:has(.app-mobile) .header__app:has(.app-desktop) {
@@ -303,82 +119,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 .header__app:has(.app-mobile) {
   display: block;
   padding: 20px 0 50px;
-}
-
-#section-header .app-mobile .weglot-widget {
-  justify-content: flex-start;
-}
-
-#section-header .app-mobile .weglot-widget__wrapper {
-  border-radius: 0;
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-#section-header .app-mobile .weglot-widget__wrapper .weglot-widget__label {
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-#section-header .app-mobile .weglot-widget__dropdown {
-  left: 0;
-  border: 1px solid var(--color-border);
-  border-radius: 0;
-  box-shadow: 0 0 8px var(--color-border);
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--up {
-  top: auto;
-  bottom: calc(100% + 11px);
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--down {
-  bottom: auto;
-  top: calc(100% + 11px);
-}
-
-#section-header .app-mobile .weglot-widget__dropdown:before,
-#section-header .app-mobile .weglot-widget__dropdown:after {
-  content: "";
-  position: absolute;
-  left: 20px;
-  width: 0px;
-  height: 0px;
-  border-style: solid;
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--up:before,
-#section-header .app-mobile .weglot-widget__dropdown--up:after {
-  top: 100%;
-  border-width: 10px 10px 0 10px;
-  border-color: var(--background-primary) transparent transparent transparent;
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--up:before {
-  top: calc(100% + 1px);
-  border-color: var(--color-border) transparent transparent transparent;
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--down:before,
-#section-header .app-mobile .weglot-widget__dropdown--down:after {
-  bottom: 100%;
-  border-width: 0 10px 10px 10px;
-  border-color: transparent transparent var(--background-primary) transparent;
-}
-
-#section-header .app-mobile .weglot-widget__dropdown--down:before {
-  bottom: calc(100% + 1px);
-  border-color: transparent transparent var(--color-border) transparent;
-}
-
-#section-header .app-mobile .weglot-widget__item {
-  transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-}
-
-@media (min-width: 768px) {
-  .header__search-wrapper {
-    min-width: 600px;
-  }
 }
 
 @media (min-width: 992px) {
@@ -419,9 +159,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
   .header__search,
   .header__mobile-menu-opener-left .header__search {
-    justify-content: flex-end;
     order: 3;
-    container: search / inline-size;
   }
 
   .header__extra-menu,
@@ -434,8 +172,7 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     order: 6;
   }
 
-  .header__content-inner.header__mobile-menu-opener-right .header__cart:nth-last-child(2),
-  .header__content-inner.header__mobile-menu-opener-right .header__search:nth-last-child(2) {
+  .header__content-inner.header__mobile-menu-opener-right .header__cart:nth-last-child(2) {
     margin-right: -7px;
   }
 
@@ -456,29 +193,8 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
     flex-grow: 1;
   }
 
-  .header__search-wrapper {
-    min-width: 350px;
-    max-width: 560px;
-    width: 100%;
-    margin: 0 0 0 auto;
-    top: calc((var(--header-height) - var(--top-bar-height, 0px) + var(--header-icon-height)) / 2);
-  }
-
-  .header__content-inner:has(.header__extra-menu) .header__search-wrapper {
-    margin: 0 auto;
-  }
-
   .header__content-inner > .header__extra-menu {
     display: block;
-  }
-
-  .header__search-wrapper,
-  .header__search:last-child .header__search-wrapper,
-  .header__search:nth-last-child(2) .header__search-wrapper,
-  .header__search:nth-last-child(2):has(+ .header__menu) .header__search-wrapper,
-  .header__mobile-menu-opener-left .header__search-wrapper,
-  .header__mobile-menu-opener-left .header__search:nth-last-child(2) .header__search-wrapper {
-    right: 0;
   }
 
   .header__app:has(.app-desktop) {
@@ -492,86 +208,6 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
 
   header:has(.app-mobile) .header__app:has(.app-desktop) {
     display: block;
-  }
-
-  #section-header .header__app [data-short-names="true"] {
-    width: auto;
-  }
-
-  #section-header .header__app .weglot-widget__label {
-    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-    color: var(--color-primary);
-  }
-
-  #section-header .header__app .weglot-widget__wrapper {
-    border-radius: var(--border-radius-badge);
-    padding: 0;
-    border: none;
-  }
-
-  #section-header .header__app .weglot-widget__wrapper:hover .weglot-widget__label {
-    color: var(--color-outline);
-  }
-
-  #section-header .header__app .weglot-widget__dropdown {
-    left: 50%;
-    transform: translate(-50%, 0);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius-badge);
-    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-    background-color: var(--background-primary) !important;
-    box-shadow: 0 0 8px var(--color-border);
-  }
-
-  #section-header .header__app .weglot-widget__dropdown:hover {
-    border-color: var(--color-outline);
-  }
-
-  #section-header .header__app .weglot-widget__dropdown--up,
-  #section-header .header__app .weglot-widget__dropdown--down {
-    top: calc(100% + 11px);
-    bottom: auto;
-  }
-
-  #section-header .header__app .weglot-widget__dropdown:before,
-  #section-header .header__app .weglot-widget__dropdown:after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
-    width: 0px;
-    height: 0px;
-    border-style: solid;
-    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-  }
-
-  #section-header .header__app .weglot-widget__dropdown--up:before,
-  #section-header .header__app .weglot-widget__dropdown--up:after,
-  #section-header .header__app .weglot-widget__dropdown--down:before,
-  #section-header .header__app .weglot-widget__dropdown--down:after {
-    bottom: 100%;
-    border-width: 0 10px 10px 10px;
-    border-color: transparent transparent var(--background-primary) transparent;
-  }
-
-  #section-header .header__app .weglot-widget__dropdown--up:before,
-  #section-header .header__app .weglot-widget__dropdown--down:before {
-    bottom: calc(100% + 1px);
-    border-color: transparent transparent var(--color-border) transparent;
-  }
-
-  #section-header .header__app .weglot-widget__dropdown--up:hover:before,
-  #section-header .header__app .weglot-widget__dropdown--down:hover:before {
-    border-color: transparent transparent var(--color-outline) transparent;
-  }
-
-  #section-header .header__app .weglot-widget__item {
-    transition: all var(--animation-duration) var(--transition-function-ease-in-out);
-    color: var(--color-primary);
-  }
-
-  #section-header .header__app .weglot-widget__item:hover {
-    color: var(--color-outline);
   }
 }
 
@@ -587,96 +223,5 @@ header:has(.app-mobile) .header__app:has(.app-desktop) {
   .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__cart),
   .header__mobile-menu-opener-left .header__logo-wrapper:has(+ .header__search + .header__cart) {
     padding-right: 22px;
-  }
-}
-
-@media (min-width: 1300px) {
-  .header__content-inner .header__search:last-child,
-  .header__content-inner.header__mobile-menu-opener-left .header__search:nth-last-child(2),
-  .header__content-inner.header__mobile-menu-opener-right .header__search:nth-last-child(2) {
-    margin-right: 0;
-  }
-}
-
-
-@container (min-width: 350px) {
-  .header__search-opener {
-    display: none;
-  }
-
-  .header__search-wrapper {
-    transition: none;
-    visibility: visible;
-    opacity: 1;
-    pointer-events: all;
-    position: relative;
-    top: 0;
-  }
-
-  .preview-bar__container ~ .header-sticky .header__search-wrapper {
-    top: 0;
-  }
-
-  .header__search-input {
-    background: var(--color-border);
-    padding-left: 11px;
-  }
-
-  .header__search-input-wrapper.filled .header__search-input {
-    padding-right: 85px;
-  }
-
-  .header__search-submit {
-    left: auto;
-    right: 2px;
-  }
-
-  .header__search-reset {
-    right: 50px;
-    width: 20px;
-  }
-
-  .header__search-input:-webkit-autofill,
-  .header__search-input:-webkit-autofill:hover,
-  .header__search-input:autofill,
-  .header__search-input:autofill:hover {
-    box-shadow: inset 0 0 0 150px var(--color-border) !important;
-  }
-}
-
-@media (hover: hover) {
-  .header__search-opener:hover g,
-  .header__search-submit:hover g,
-  .header__search-icon:hover g {
-    stroke: var(--color-outline);
-  }
-
-  .header__search-reset:hover:after,
-  .header__search-reset:hover:before {
-    background: var(--color-outline);
-  }
-
-  #section-header .app-mobile .weglot-widget__wrapper:hover {
-    border-color: var(--color-outline);
-  }
-
-  #section-header .app-mobile .weglot-widget__wrapper:hover .weglot-widget__label {
-    color: var(--color-outline);
-  }
-
-  #section-header .app-mobile .weglot-widget__dropdown:hover {
-    border-color: var(--color-outline);
-  }
-
-  #section-header .app-mobile .weglot-widget__dropdown--up:hover:before {
-    border-color: var(--color-outline) transparent transparent transparent;
-  }
-
-  #section-header .app-mobile .weglot-widget__dropdown--down:hover:before {
-    border-color: transparent transparent var(--color-outline) transparent;
-  }
-
-  #section-header .app-mobile .weglot-widget__item:hover {
-    color: var(--color-outline);
   }
 }

--- a/assets/search-form.css
+++ b/assets/search-form.css
@@ -25,10 +25,6 @@
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
 }
 
-.search-form__label {
-  display: none;
-}
-
 .search-form__submit {
   position: absolute;
   top: 50%;
@@ -163,7 +159,7 @@
 }
 
 .header__content-inner .search-form:last-child,
-.header__content-inner.header__mobile-menu-opener-left .search-form:nth-last-child(2) {
+.header__mobile-menu-opener-left .search-form:nth-last-child(2) {
   margin-right: -7px;
 }
 
@@ -175,12 +171,12 @@
   right: 7px;
 }
 
-.loaded .search-form__wrapper {
-  display: block !important;
-}
-
 .preview-bar__container ~ .header-sticky .search-form__wrapper {
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
+}
+
+.loaded .search-form__wrapper {
+  display: block !important;
 }
 
 .touch[data-orientation='landscape'] .search-form__wrapper,
@@ -195,12 +191,10 @@
   }
 }
 
-@media (min-width: 1100px) {
+@media (min-width: 992px) {
   .search-form,
   .header__mobile-menu-opener-left .search-form {
     justify-content: flex-end;
-    grid-column: 2;
-    grid-row: 1;
     container: search / inline-size;
   }
 
@@ -216,6 +210,10 @@
     top: calc((var(--header-height) - var(--top-bar-height, 0px) + var(--header-icon-height)) / 2);
   }
 
+  .header__content-inner:has(.header__extra-menu) .search-form__wrapper {
+    margin: 0 auto;
+  }
+
   .search-form__wrapper,
   .search-form:last-child .search-form__wrapper,
   .search-form:nth-last-child(2) .search-form__wrapper,
@@ -223,25 +221,6 @@
   .header__mobile-menu-opener-left .search-form__wrapper,
   .header__mobile-menu-opener-left .search-form:nth-last-child(2) .search-form__wrapper {
     right: 0;
-  }
-
-  .search-form__submit:has(.search-form__label) {
-    width: auto;
-    height: calc(100% - 8px);
-  }
-
-  .search-form__submit:has(.search-form__label) .search-form__icon {
-    display: none;
-  }
-
-  .search-form__submit:has(.search-form__label) .search-form__label {
-    display: flex;
-    align-items: center;
-    justify-content: start;
-    height: 100%;
-    padding: 5px 20px;
-    margin: 0;
-    line-height: 1;
   }
 }
 
@@ -272,6 +251,7 @@
   }
 
   .search-form__input {
+    background: var(--color-border);
     padding-left: 11px;
   }
 
@@ -279,17 +259,9 @@
     padding-right: 85px;
   }
 
-  .search-form__input-wrapper.filled:has(.search-form__label) .search-form__input {
-    padding-right: 150px;
-  }
-
   .search-form__submit {
     left: auto;
     right: 2px;
-  }
-
-  .search-form__submit:has(.search-form__label) {
-    right: 4px;
   }
 
   .search-form__reset {
@@ -297,8 +269,11 @@
     width: 20px;
   }
 
-  .search-form__input-wrapper.filled:has(.search-form__label) .search-form__reset {
-    right: 124px;
+  .search-form__input:-webkit-autofill,
+  .search-form__input:-webkit-autofill:hover,
+  .search-form__input:autofill,
+  .search-form__input:autofill:hover {
+    box-shadow: inset 0 0 0 150px var(--color-border) !important;
   }
 }
 

--- a/assets/search.js
+++ b/assets/search.js
@@ -3,11 +3,11 @@ class Search {
     this.search = search;
 
     this.selector = {
-      search: ".header__search",
+      search: ".search-form",
       searchForm: "#search",
       searchOpener: "#search-opener",
-      searchInput: ".header__search-input",
-      searchReset: ".header__search-reset"
+      searchInput: ".search-form__input",
+      searchReset: ".search-form__reset"
     }
 
     this.classes = {
@@ -118,7 +118,7 @@ class Search {
   }
 }
 
-const initSearch = new Search(document.querySelector('.header__search'));
+const initSearch = new Search(document.querySelector('.search-form'));
 
 document.addEventListener("readystatechange", (e) => {
   if (e.target.readyState === "complete") initSearch.init();

--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -109,26 +109,62 @@
         },
         "header": {
           "type": "header",
-          "blocks": {},
-          "block_order": [],
+          "blocks": {
+            "info_894203": {
+              "type": "info",
+              "settings": {
+                "support_icon": "phone",
+                "support_label": "+1 555 302 8549",
+                "support_url": "tel:+15553028549"
+              },
+              "disabled": null
+            },
+            "info_894204": {
+              "type": "info",
+              "settings": {
+                "support_icon": "comment",
+                "support_label": "Chat with us",
+                "support_url": "support-url.example"
+              },
+              "disabled": null
+            },
+            "info_894205": {
+              "type": "info",
+              "settings": {
+                "support_icon": "envelope",
+                "support_label": "info@example.com",
+                "support_url": "mailto:info@example.com"
+              },
+              "disabled": null
+            }
+          },
+          "block_order": [
+            "info_894203",
+            "info_894204",
+            "info_894205"
+          ],
           "settings": {
             "color_scheme": "set-1",
             "custom_title": "{{ shop.name }}",
             "logo": "booqable://assets/image-store-logo.png",
-            "menu_main": "main-menu",
-            "menu_additional": "additional-menu",
             "menu_back_mobile": "Back",
+            "menu_main": "main-menu",
             "menu_message_mobile": "Mon - Fri: 10:00 - 18:00",
             "menu_message_mobile_icon": "clock",
             "menu_opener_label": "Collections",
             "menu_opener_mobile": "right",
+            "menu_secondary": "main-menu",
+            "menu_third": "additional-menu",
             "padding_bottom": "large",
             "padding_bottom_mobile": "small",
             "padding_top": "large",
             "padding_top_mobile": "small",
+            "search_label": "SEARCH",
             "search_placeholder": "Search for products",
             "show_search": true,
-            "sticky_header": true
+            "show_support": true,
+            "sticky_header": true,
+            "support_icon_opener": "headset"
           },
           "disabled": null
         },

--- a/sections/adore/header.liquid
+++ b/sections/adore/header.liquid
@@ -258,31 +258,11 @@
 
 {%- if show_search -%}
   {%- capture header_search -%}
-    <div class="header__search">
-      <input type="checkbox" id="search-opener" style="display: none">
-      <label for="search-opener" class="header__search-opener">
-        {%- render 'icon-search' -%}
-      </label>
-
-      <div class="header__search-wrapper" style="display: none">
-        <form id="search" action="{{ routes.search_url }}" role="search">
-          <div class="header__search-input-wrapper">
-            <button class="header__search-submit" type="submit">
-              {%- if search_label != blank -%}
-                <span class="header__search-label{% if search_label != blank %} button button--primary{%- endif -%}">
-                  {{- search_label -}}
-                </span>
-              {%- endif -%}
-              <i class="header__search-icon">
-                {%- render 'icon-search' -%}
-              </i>
-            </button>
-            <input type="search" name="q" class="header__search-input" placeholder="{{- search_placeholder -}}">
-            <span class="header__search-reset"></span>
-          </div>
-        </form>
-      </div>
-    </div>
+    {%- render 'search-form',
+        routes: routes,
+        search_button_label: search_label,
+        search_placeholder: search_placeholder
+    -%}
   {%- endcapture -%}
 {%- endif -%}
 

--- a/sections/adore/header.liquid
+++ b/sections/adore/header.liquid
@@ -1,25 +1,44 @@
 {{ "header.css" | asset_url | stylesheet_tag }}
-{{ "menu.css" | asset_url | stylesheet_tag }}
 
 {%- assign app                            = section.blocks | where: "type", "app" | first -%}
 {%- assign color_scheme                   = section.settings.color_scheme -%}
 {%- assign custom_title                   = section.settings.custom_title -%}
+{%- assign icon_style                     = settings.icon_style -%}
 {%- assign logo                           = section.settings.logo -%}
 {%- assign menu_main                      = section.settings.menu_main -%}
-{%- assign menu_additional                = section.settings.menu_additional -%}
+{%- assign menu_secondary                 = section.settings.menu_secondary -%}
+{%- assign menu_third                     = section.settings.menu_third -%}
 {%- assign menu_back_mobile               = section.settings.menu_back_mobile -%}
 {%- assign menu_message_mobile            = section.settings.menu_message_mobile -%}
 {%- assign menu_message_mobile_icon       = section.settings.menu_message_mobile_icon -%}
-{%- assign menu_message_mobile_icon_style = settings.icon_style -%}
 {%- assign menu_opener_label              = section.settings.menu_opener_label -%}
 {%- assign menu_opener_mobile             = section.settings.menu_opener_mobile -%}
 {%- assign padding_bottom                 = section.settings.padding_bottom -%}
 {%- assign padding_bottom_mobile          = section.settings.padding_bottom_mobile -%}
 {%- assign padding_top                    = section.settings.padding_top -%}
 {%- assign padding_top_mobile             = section.settings.padding_top_mobile -%}
+{%- assign search_label                   = section.settings.search_label -%}
 {%- assign search_placeholder             = section.settings.search_placeholder -%}
 {%- assign show_search                    = section.settings.show_search -%}
+{%- assign show_support                   = section.settings.show_support -%}
 {%- assign sticky_header                  = section.settings.sticky_header -%}
+{%- assign support_icon_opener            = section.settings.support_icon_opener -%}
+
+{%- if menu_main != blank or menu_secondary != blank or menu_third != blank -%}
+  {{ "menu.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
+{%- if show_search -%}
+  {{ "search-form.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
+{%- if show_support -%}
+  {{ "support.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
+{%- if app != blank -%}
+  {{ "app.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -83,14 +102,59 @@
   {%- endif -%}
 {%- endcapture -%}
 
-{%- if menu_additional != blank -%}
+{%- if show_support -%}
+  {%- capture header_icons -%}
+    <div class="header__support support">
+      {%- if support_icon_opener != "empty" -%}
+        <input type="checkbox" id="support-opener" style="display: none">
+        <label for="support-opener" class="header__support-opener support__opener">
+          {%- render 'icon',
+              icon: support_icon_opener,
+              style: icon_style
+          -%}
+        </label>
+      {%- endif -%}
+
+      <div class="header__support-wrapper support__wrapper"{% if support_icon_opener != "empty" %} style="display: none"{%- endif -%}>
+        {%- for block in section.blocks -%}
+          {%- assign block_index   = forloop.index -%}
+          {%- assign support_icon  = block.settings.support_icon -%}
+          {%- assign support_label = block.settings.support_label -%}
+          {%- assign support_url   = block.settings.support_url -%}
+
+          {%- if block_index > 2 and support_icon_opener == "empty" -%}
+            {%- break -%}
+          {%- endif -%}
+
+          <div class="support__item">
+            {%- if support_icon != "empty" and support_label != blank -%}
+              <i class="support__icon">
+                {%- render 'icon',
+                    icon: support_icon,
+                    style: icon_style
+                -%}
+              </i>
+            {%- endif -%}
+            {%- if support_label != blank -%}
+              <a href="{{ support_url }}" class="support__link">
+                {{- support_label -}}
+              </a>
+            {%- endif -%}
+          </div>
+        {%- endfor -%}
+      </div>
+    </div>
+  {%- endcapture -%}
+{%- endif -%}
+
+{%- if menu_third != blank -%}
   {%- capture header_menu_small -%}
-    <nav class="header__extra-menu extra-menu">
-      <ul class="extra-menu__list">
-        {%- for link in menu_additional.items -%}
+    <nav class="header__menu-third menu-third">
+      <ul class="menu-third__list">
+        {%- for link in menu_third.items -%}
           {%- if link != blank -%}
-            <li class="extra-menu__item">
-              <a href="{{ link.url }}" class="extra-menu__link">
+            <li class="menu-third__item">
+              <a href="{{ link.url }}" class="menu-third__link">
                 {{- link.title -}}
               </a>
             </li>
@@ -121,6 +185,15 @@
               {%- render 'mega-menu',
                   menu: menu_main,
                   class: "menu",
+                  count: "1",
+                  back_button_label: menu_back_mobile
+              -%}
+
+              {%- render 'mega-menu',
+                  menu: menu_secondary,
+                  class: "menu",
+                  hidden_class: "desktop-hidden",
+                  count: "2",
                   back_button_label: menu_back_mobile
               -%}
             </ul>
@@ -134,14 +207,33 @@
             </div>
           {%- endif -%}
 
+          {{- header_icons -}}
+
           {%- if menu_message_mobile != blank -%}
             <div class="menu__message">
-              {%- render 'icon', icon: menu_message_mobile_icon, style: menu_message_mobile_icon_style -%}
+              {%- render 'icon', icon: menu_message_mobile_icon, style: icon_style -%}
 
               <div class="menu__message-text">{{- menu_message_mobile -}}</div>
             </div>
           {%- endif -%}
         </div>
+      </div>
+    </div>
+  {%- endcapture -%}
+{%- endif -%}
+
+{%- if menu_secondary != blank -%}
+  {%- capture header_menu_secondary -%}
+    <div class="header__menu-secondary menu-secondary header__menu-secondary--mobile-hidden">
+      <div class="header__nav-secondary menu-secondary__nav">
+        <nav class="menu-secondary__wrapper">
+          <ul class="menu-secondary__list">
+            {%- render 'mega-menu',
+                menu: menu_secondary,
+                class: "menu-secondary"
+            -%}
+          </ul>
+        </nav>
       </div>
     </div>
   {%- endcapture -%}
@@ -176,6 +268,11 @@
         <form id="search" action="{{ routes.search_url }}" role="search">
           <div class="header__search-input-wrapper">
             <button class="header__search-submit" type="submit">
+              {%- if search_label != blank -%}
+                <span class="header__search-label{% if search_label != blank %} button button--primary{%- endif -%}">
+                  {{- search_label -}}
+                </span>
+              {%- endif -%}
               <i class="header__search-icon">
                 {%- render 'icon-search' -%}
               </i>
@@ -197,6 +294,8 @@
 
         {{- header_menu_small -}}
 
+        {{- header_menu_secondary -}}
+
         <div class="header__logo-wrapper">
           <a href="{{ routes.root_url }}" class="header__logo">
             {{- header_logo -}}
@@ -204,6 +303,8 @@
         </div>
 
         {{- header_search -}}
+
+        {{- header_icons -}}
 
         {{- header_cart_button -}}
 
@@ -233,6 +334,12 @@
         "content": "General settings"
       },
       {
+        "type": "checkbox",
+        "id": "sticky_header",
+        "default": true,
+        "label": "Stick to top"
+      },
+      {
         "type": "image_picker",
         "id": "logo",
         "label": "Logo"
@@ -250,20 +357,27 @@
         "default": "set-1"
       },
       {
+        "type": "header",
+        "content": "Menus"
+      },
+      {
         "type": "menu",
         "id": "menu_main",
         "label": "General menu"
       },
       {
         "type": "menu",
-        "id": "menu_additional",
+        "id": "menu_secondary",
+        "label": "Secondary menu"
+      },
+      {
+        "type": "menu",
+        "id": "menu_third",
         "label": "Small menu"
       },
       {
-        "type": "checkbox",
-        "id": "sticky_header",
-        "default": true,
-        "label": "Stick to top"
+        "type": "header",
+        "content": "Search"
       },
       {
         "type": "checkbox",
@@ -274,8 +388,64 @@
       {
         "type": "text",
         "id": "search_placeholder",
-        "label": "Search placeholder",
+        "label": "Placeholder",
+        "default": "What are you looking for?"
+      },
+      {
+        "type": "text",
+        "id": "search_label",
+        "label": "Button label",
         "default": "Search"
+      },
+      {
+        "type": "header",
+        "content": "Support"
+      },
+      {
+        "type": "checkbox",
+        "id": "show_support",
+        "default": true,
+        "label": "Show support"
+      },
+      {
+        "type": "select",
+        "id": "support_icon_opener",
+        "label": "Opener icon",
+        "options": [
+          {
+            "value": "empty",
+            "label": "No icon"
+          },
+          {
+            "value": "comment",
+            "label": "Comment"
+          },
+          {
+            "value": "envelope",
+            "label": "Envelope"
+          },
+          {
+            "value": "fax",
+            "label": "Fax"
+          },
+          {
+            "value": "headset",
+            "label": "Headset"
+          },
+          {
+            "value": "info",
+            "label": "Info"
+          },
+          {
+            "value": "phone",
+            "label": "Phone"
+          }
+        ],
+        "default": "headset"
+      },
+      {
+        "type": "paragraph",
+        "content": "Other information can be added with blocks"
       },
       {
         "type": "header",
@@ -463,6 +633,53 @@
       }
     ],
     "blocks": [
+      {
+        "type": "info",
+        "name": "Info",
+        "limit": 8,
+        "settings": [
+          {
+            "type": "select",
+            "id": "support_icon",
+            "label": "Icon",
+            "options": [
+              {
+                "value": "empty",
+                "label": "No icon"
+              },
+              {
+                "value": "comment",
+                "label": "Comment"
+              },
+              {
+                "value": "envelope",
+                "label": "Envelope"
+              },
+              {
+                "value": "fax",
+                "label": "Fax"
+              },
+              {
+                "value": "phone",
+                "label": "Phone"
+              }
+            ],
+            "default": "phone"
+          },
+          {
+            "type": "text",
+            "id": "support_label",
+            "label": "Label",
+            "default": "+1 755 302 8549"
+          },
+          {
+            "type": "url",
+            "id": "support_url",
+            "label": "Link",
+            "default": "tel:+17553028549"
+          }
+        ]
+      },
       {
         "type": "@app"
       }

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -1,5 +1,4 @@
 {{ "header.css" | asset_url | stylesheet_tag }}
-{{ "menu.css" | asset_url | stylesheet_tag }}
 
 {%- assign app                            = section.blocks | where: "type", "app" | first -%}
 {%- assign color_scheme                   = section.settings.color_scheme -%}
@@ -20,6 +19,18 @@
 {%- assign search_placeholder             = section.settings.search_placeholder -%}
 {%- assign show_search                    = section.settings.show_search -%}
 {%- assign sticky_header                  = section.settings.sticky_header -%}
+
+{%- if menu_main != blank or menu_additional != blank -%}
+  {{ "menu.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
+{%- if show_search -%}
+  {{ "search-form.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
+{%- if app != blank -%}
+  {{ "app.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -166,26 +177,10 @@
 
 {%- if show_search -%}
   {%- capture header_search -%}
-    <div class="header__search">
-      <input type="checkbox" id="search-opener" style="display: none">
-      <label for="search-opener" class="header__search-opener">
-        {%- render 'icon-search' -%}
-      </label>
-
-      <div class="header__search-wrapper" style="display: none">
-        <form id="search" action="{{ routes.search_url }}" role="search">
-          <div class="header__search-input-wrapper">
-            <button class="header__search-submit" type="submit">
-              <i class="header__search-icon">
-                {%- render 'icon-search' -%}
-              </i>
-            </button>
-            <input type="search" name="q" class="header__search-input" placeholder="{{- search_placeholder -}}">
-            <span class="header__search-reset"></span>
-          </div>
-        </form>
-      </div>
-    </div>
+    {%- render 'search-form',
+        routes: routes,
+        search_placeholder: search_placeholder
+    -%}
   {%- endcapture -%}
 {%- endif -%}
 

--- a/snippets/mega-menu.liquid
+++ b/snippets/mega-menu.liquid
@@ -1,0 +1,118 @@
+{% comment %}
+
+  This snippet is used for rendering the menu
+
+  menu - object *required,
+  class - "string" *required,
+  hidden_class - "string" optional,
+  count - "string" *required,
+  back_button_label - "string" optional
+
+  Usage:
+
+  {%- render 'mega-menu',
+      menu: your_id,
+      class: your_id,
+      hidden_class: your_id,
+      count: your_id,
+      back_button_label: your_id
+  -%}
+
+{% endcomment %}
+
+{%- for link in menu.items -%}
+  {%- assign link_index = forloop.index -%}
+
+  {%- if link != blank -%}
+    <li class="{{- class -}}__item{% if hidden_class != blank %} {{ class }}__item--{{- hidden_class -}}{% endif %}{% if link.items_count > 0 %} has-dropdown{%- endif -%}">
+      {%- if link.items_count > 0 -%}
+        <input type="checkbox" id="dropdown-{{- class -}}-trigger-{{- count -}}-{{- link_index -}}" style="display: none;">
+        <label for="dropdown-{{- class -}}-trigger-{{- count -}}-{{- link_index -}}" class="{{- class -}}__dropdown-opener">
+          <i class="{{- class -}}__item-icon">
+            {%- render 'icon-arrow-down' -%}
+          </i>
+        </label>
+      {%- endif -%}
+
+      <a href="{{ link.url }}" class="{{- class -}}__link">
+        {{- link.title -}}
+      </a>
+
+      {%- if link.items_count > 0 -%}
+        <div class="{{- class -}}__dropdown" style="display: none;">
+          <div class="{{- class -}}__dropdown-wrapper">
+            <label for="dropdown-{{- class -}}-trigger-{{- count -}}-{{- link_index -}}" class="{{- class -}}__dropdown-opener {{ class -}}__dropdown-back">
+              <i class="{{- class -}}__item-icon">
+                {%- render 'icon-arrow-down' -%}
+              </i>
+
+              {%- if back_button_label != blank -%}
+                {{- back_button_label -}}
+              {%- endif -%}
+            </label>
+
+            <div class="{{- class -}}__dropdown-title">
+              {{- link.title -}}
+            </div>
+
+            <ul class="{{- class -}}__dropdown-list">
+              {%- for childlink in link.items -%}
+                {%- assign childlink_index = forloop.index -%}
+
+                {%- if childlink != blank -%}
+                  <li class="{{- class -}}__dropdown-item">
+                    {%- if childlink.items_count > 0 -%}
+                      <input type="checkbox" id="dropdown-child{{- class -}}-trigger-{{- count -}}-{{- link_index -}}-{{- childlink_index -}}" style="display: none;">
+                      <label for="dropdown-child{{- class -}}-trigger-{{- count -}}-{{- link_index -}}-{{- childlink_index -}}" class="{{- class -}}__dropdown-opener">
+                        <i class="{{- class -}}__item-icon">
+                          {%- render 'icon-arrow-down' -%}
+                        </i>
+                      </label>
+                    {%- endif -%}
+
+                    <a href="{{ childlink.url }}" class="{{- class -}}__dropdown-link">
+                      {{- childlink.title -}}
+                    </a>
+
+                    {%- if childlink.items_count > 0 -%}
+                      <div class="{{- class -}}__dropdown">
+                        <div class="{{- class -}}__dropdown-wrapper">
+
+                          <label for="dropdown-child{{- class -}}-trigger-{{- count -}}-{{- link_index -}}-{{- childlink_index -}}" class="{{- class -}}__dropdown-opener {{ class -}}__dropdown-back">
+                            <i class="{{- class -}}__item-icon">
+                              {%- render 'icon-arrow-down' -%}
+                            </i>
+
+                            {%- if back_button_label != blank -%}
+                              {{- back_button_label -}}
+                            {%- endif -%}
+                          </label>
+
+                          <div class="{{- class -}}__dropdown-title">
+                            {{- childlink.title -}}
+                          </div>
+
+                          <ul class="{{- class -}}__dropdown-list">
+                            {%- for grandchildlink in childlink.items -%}
+                              {%- if grandchildlink != blank -%}
+                                <li class="{{- class -}}__dropdown-item">
+                                  <a href="{{ grandchildlink.url }}" class="{{- class -}}__dropdown-link">
+                                    {{- grandchildlink.title -}}
+                                  </a>
+                                </li>
+                              {%- endif -%}
+                            {%- endfor -%}
+                          </ul>
+                        </div>
+                      </div>
+                    {%- endif -%}
+                  </li>
+                {%- endif -%}
+              {%- endfor -%}
+            </ul>
+          </div>
+        </div>
+      {%- endif -%}
+    </li>
+  {%- endif -%}
+{%- endfor -%}

--- a/snippets/search-form.liquid
+++ b/snippets/search-form.liquid
@@ -1,0 +1,43 @@
+{% comment %}
+
+  This snippet is used for rendering the search form in the header.
+
+  search_button_label - "string" *reqiured,
+  search_placeholder - "string" optional,
+  routes - {object} *required
+
+  Usage:
+
+  {%- render 'search-form',
+      routes: routes,
+      search_button_label: your_id,
+      search_placeholder: your_id
+  -%}
+
+{% endcomment %}
+
+<div class="header__search search-form">
+  <input type="checkbox" id="search-opener" style="display: none">
+  <label for="search-opener" class="search-form__opener">
+    {%- render 'icon-search' -%}
+  </label>
+
+  <div class="search-form__wrapper" style="display: none">
+    <form id="search" action="{{ routes.search_url }}" role="search">
+      <div class="search-form__input-wrapper">
+        <button class="search-form__submit" type="submit">
+          {%- if search_button_label != blank -%}
+            <span class="search-form__label{% if search_button_label != blank %} button button--primary{%- endif -%}">
+              {{- search_button_label -}}
+            </span>
+          {%- endif -%}
+          <i class="search-form__icon">
+            {%- render 'icon-search' -%}
+          </i>
+        </button>
+        <input type="search" name="q" class="search-form__input" placeholder="{{- search_placeholder -}}">
+        <span class="search-form__reset"></span>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
This PR's goal is to implement a new header for the Adore variant of theme

Some elements are reused in both headers so they were separated into the snippets

Before:
![Arc_2024-09-02 16-04-06@2x](https://github.com/user-attachments/assets/02db7674-9057-4619-81df-8175c6c31e49)


After:
![Teampaper_2024-09-02 16-01-53@2x](https://github.com/user-attachments/assets/7944bf96-132e-4fbe-bed6-95e35b7035e1)
![Arc_2024-09-02 16-02-04@2x](https://github.com/user-attachments/assets/3ad531e2-8209-43fd-b21c-0d29ae5a7a30)

