### PR TITLE
Fix issue when previews of blocks show wrong information or missed at all

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -113,27 +113,27 @@
             "info_894203": {
               "type": "info",
               "settings": {
-                "support_icon": "phone",
-                "support_label": "+1 555 302 8549",
-                "support_url": "tel:+15553028549"
+                "heading": "+1 555 302 8549",
+                "icon": "phone",
+                "url": "tel:+15553028549"
               },
               "disabled": null
             },
             "info_894204": {
               "type": "info",
               "settings": {
-                "support_icon": "comment",
-                "support_label": "Chat with us",
-                "support_url": "support-url.example"
+                "heading": "Chat with us",
+                "icon": "comment",
+                "url": "support-url.example"
               },
               "disabled": null
             },
             "info_894205": {
               "type": "info",
               "settings": {
-                "support_icon": "envelope",
-                "support_label": "info@example.com",
-                "support_url": "mailto:info@example.com"
+                "heading": "info@example.com",
+                "icon": "envelope",
+                "url": "mailto:info@example.com"
               },
               "disabled": null
             }

--- a/sections/adore/header.liquid
+++ b/sections/adore/header.liquid
@@ -117,27 +117,27 @@
 
       <div class="header__support-wrapper support__wrapper"{% if support_icon_opener != "empty" %} style="display: none"{%- endif -%}>
         {%- for block in section.blocks -%}
-          {%- assign block_index   = forloop.index -%}
-          {%- assign support_icon  = block.settings.support_icon -%}
-          {%- assign support_label = block.settings.support_label -%}
-          {%- assign support_url   = block.settings.support_url -%}
+          {%- assign block_index = forloop.index -%}
+          {%- assign heading     = block.settings.heading -%}
+          {%- assign icon        = block.settings.icon -%}
+          {%- assign url         = block.settings.url -%}
 
           {%- if block_index > 2 and support_icon_opener == "empty" -%}
             {%- break -%}
           {%- endif -%}
 
           <div class="support__item">
-            {%- if support_icon != "empty" and support_label != blank -%}
+            {%- if icon != "empty" and heading != blank -%}
               <i class="support__icon">
                 {%- render 'icon',
-                    icon: support_icon,
+                    icon: icon,
                     style: icon_style
                 -%}
               </i>
             {%- endif -%}
-            {%- if support_label != blank -%}
-              <a href="{{ support_url }}" class="support__link">
-                {{- support_label -}}
+            {%- if heading != blank -%}
+              <a href="{{ url }}" class="support__link">
+                {{- heading -}}
               </a>
             {%- endif -%}
           </div>
@@ -620,7 +620,7 @@
         "settings": [
           {
             "type": "select",
-            "id": "support_icon",
+            "id": "icon",
             "label": "Icon",
             "options": [
               {
@@ -648,13 +648,13 @@
           },
           {
             "type": "text",
-            "id": "support_label",
+            "id": "heading",
             "label": "Label",
             "default": "+1 755 302 8549"
           },
           {
             "type": "url",
-            "id": "support_url",
+            "id": "url",
             "label": "Link",
             "default": "tel:+17553028549"
           }

--- a/sections/articles.liquid
+++ b/sections/articles.liquid
@@ -85,9 +85,9 @@
           {%- assign article_btn     = block.settings.article_btn -%}
           {%- assign article_btn_url = block.settings.article_btn_url -%}
           {%- assign article_tag     = block.settings.article_tag -%}
+          {%- assign article_text    = block.settings.article_text -%}
           {%- assign heading         = block.settings.heading -%}
           {%- assign image           = block.settings.image -%}
-          {%- assign text            = block.settings.text -%}
 
           {%- if image != blank -%}
             {%- assign image = image -%}
@@ -111,7 +111,7 @@
               {%- endif -%}
             </div>
 
-            {%- if article_tag != blank or heading != blank or text != blank or article_btn != blank and article_btn_url != blank -%}
+            {%- if article_tag != blank or heading != blank or article_text != blank or article_btn != blank and article_btn_url != blank -%}
               <div class="article__text-area">
                 {%- if article_tag != blank -%}
                   <strong class="article__tag tagline">{{- article_tag -}}</strong>
@@ -121,8 +121,8 @@
                   <h3 class="article__heading h5">{{- heading -}}</h3>
                 {%- endif -%}
 
-                {%- if text != blank -%}
-                  <div class="article__text bq-content rx-content">{{- text -}}</div>
+                {%- if article_text != blank -%}
+                  <div class="article__text bq-content rx-content">{{- article_text -}}</div>
                 {%- endif -%}
 
                 {%- if article_btn != blank and article_btn_url != blank -%}
@@ -324,7 +324,7 @@
           },
           {
             "type": "contentEditor",
-            "id": "text",
+            "id": "article_text",
             "label": "Description",
             "default": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat."
           },

--- a/sections/columns.liquid
+++ b/sections/columns.liquid
@@ -123,18 +123,18 @@
 
           {%- case type -%}
             {%- when 'card' -%}
-              {%- assign description   = block.settings.description_card -%}
-              {%- assign card          = true -%}
-              {%- assign icon          = block.settings.icon -%}
-              {%- assign title         = block.settings.title_card -%}
+              {%- assign card         = true -%}
+              {%- assign description  = block.settings.description -%}
+              {%- assign icon         = block.settings.icon -%}
+              {%- assign title        = block.settings.title -%}
 
             {%- when 'deco' -%}
               {%- assign button_label = block.settings.button_label -%}
               {%- assign button_url   = block.settings.button_url -%}
               {%- assign deco         = true -%}
-              {%- assign description  = block.settings.description_deco -%}
+              {%- assign description  = block.settings.description -%}
               {%- assign image        = block.settings.image -%}
-              {%- assign title        = block.settings.title_deco -%}
+              {%- assign title        = block.settings.title -%}
 
               {%- if image != blank -%}
                 {%- assign image = image -%}
@@ -460,13 +460,13 @@
         "settings": [
           {
             "type": "text",
-            "id": "title_card",
+            "id": "title",
             "label": "Title",
             "default": "Medium size title here"
           },
           {
             "type": "text",
-            "id": "description_card",
+            "id": "description",
             "label": "Description",
             "default": "Lorem ipsum dolor sit amet"
           },
@@ -558,13 +558,13 @@
         "settings": [
           {
             "type": "text",
-            "id": "title_deco",
+            "id": "title",
             "label": "Title",
             "default": "Title here"
           },
           {
             "type": "text",
-            "id": "description_deco",
+            "id": "description",
             "label": "Description",
             "default": "Lorem ipsum dolor sit amet"
           },

--- a/templates/adore/index.json
+++ b/templates/adore/index.json
@@ -51,36 +51,36 @@
         "card_894203": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "truck-fast",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "Free delivery"
+            "title": "Free delivery"
           },
           "disabled": null
         },
         "card_894204": {
           "type": "card",
           "settings": {
+            "description": "Chat with us if you’ve any questions",
             "icon": "comment",
-            "description_card": "Chat with us if you’ve any questions",
-            "title_card": "Top-Notch support"
+            "title": "Top-Notch support"
           },
           "disabled": null
         },
         "card_894205": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "handshake",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "100% Satisfaction Guarantee!"
+            "title": "100% Satisfaction Guarantee!"
           },
           "disabled": null
         },
         "card_894206": {
           "type": "card",
           "settings": {
+            "description": "We know how to do it",
             "icon": "exclamation",
-            "description_card": "We know how to do it",
-            "title_card": "20 years of experience"
+            "title": "20 years of experience"
           },
           "disabled": null
         }
@@ -560,9 +560,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "Get the best routes to explore The Netherlands",
-            "image": "booqable://assets/image-article-1.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-1.jpeg"
           },
           "disabled": null
         },
@@ -572,9 +572,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "New in store | The electric offroad bike",
-            "image": "booqable://assets/image-article-2.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-2.jpeg"
           },
           "disabled": null
         },
@@ -584,9 +584,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "Ride safe, have fun 10 tips to ride safe",
-            "image": "booqable://assets/image-article-3.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-3.jpeg"
           },
           "disabled": null
         }
@@ -618,8 +618,8 @@
         "card_810203": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "truck-fast",
-            "description_card": "Free delivery for all orders above $100",
             "title_card": "Free delivery"
           },
           "disabled": null
@@ -627,8 +627,8 @@
         "card_810204": {
           "type": "card",
           "settings": {
+            "description": "Chat with us if you’ve any questions",
             "icon": "comment",
-            "description_card": "Chat with us if you’ve any questions",
             "title_card": "Top-Notch support"
           },
           "disabled": null
@@ -636,8 +636,8 @@
         "card_810205": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "handshake",
-            "description_card": "Free delivery for all orders above $100",
             "title_card": "100% Satisfaction Guarantee!"
           },
           "disabled": null
@@ -645,8 +645,8 @@
         "card_810206": {
           "type": "card",
           "settings": {
+            "description": "We know how to do it",
             "icon": "exclamation",
-            "description_card": "We know how to do it",
             "title_card": "20 years of experience"
           },
           "disabled": null

--- a/templates/bliss/index.json
+++ b/templates/bliss/index.json
@@ -264,9 +264,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-1.png",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         },
@@ -275,9 +275,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-2.png",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         },
@@ -286,9 +286,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-3.png",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         }
@@ -510,9 +510,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "A Guide On The Maid Of Honor’s Duties",
-            "image": "booqable://assets/image-article-1.jpg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-1.jpg"
           },
           "disabled": null
         },
@@ -522,9 +522,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "The Wedding Favor Ideas Guide",
-            "image": "booqable://assets/image-article-2.jpg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-2.jpg"
           },
           "disabled": null
         },
@@ -534,9 +534,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "The Wedding Order Of Events Guide",
-            "image": "booqable://assets/image-article-3.jpg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-3.jpg"
           },
           "disabled": null
         }
@@ -594,36 +594,36 @@
         "card_401203": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "truck-fast",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "Free delivery"
+            "title": "Free delivery"
           },
           "disabled": null
         },
         "card_401204": {
           "type": "card",
           "settings": {
+            "description": "Chat with us if you’ve any questions",
             "icon": "comment",
-            "description_card": "Chat with us if you’ve any questions",
-            "title_card": "Top-Notch support"
+            "title": "Top-Notch support"
           },
           "disabled": null
         },
         "card_401205": {
           "type": "card",
           "settings": {
+            "description": "Free delivery for all orders above $100",
             "icon": "handshake",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "100% Satisfaction Guarantee!"
+            "title": "100% Satisfaction Guarantee!"
           },
           "disabled": null
         },
         "card_401206": {
           "type": "card",
           "settings": {
+            "description": "We know how to do it",
             "icon": "exclamation",
-            "description_card": "We know how to do it",
-            "title_card": "20 years of experience"
+            "title": "20 years of experience"
           },
           "disabled": null
         }

--- a/templates/spring/index.json
+++ b/templates/spring/index.json
@@ -52,8 +52,8 @@
           "type": "card",
           "settings": {
             "icon": "truck-fast",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "Free delivery"
+            "description": "Free delivery for all orders above $100",
+            "title": "Free delivery"
           },
           "disabled": null
         },
@@ -61,8 +61,8 @@
           "type": "card",
           "settings": {
             "icon": "comment",
-            "description_card": "Chat with us if you’ve any questions",
-            "title_card": "Top-Notch support"
+            "description": "Chat with us if you’ve any questions",
+            "title": "Top-Notch support"
           },
           "disabled": null
         },
@@ -70,8 +70,8 @@
           "type": "card",
           "settings": {
             "icon": "handshake",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "100% Satisfaction Guarantee!"
+            "description": "Free delivery for all orders above $100",
+            "title": "100% Satisfaction Guarantee!"
           },
           "disabled": null
         },
@@ -79,8 +79,8 @@
           "type": "card",
           "settings": {
             "icon": "exclamation",
-            "description_card": "We know how to do it",
-            "title_card": "20 years of experience"
+            "description": "We know how to do it",
+            "title": "20 years of experience"
           },
           "disabled": null
         }
@@ -273,9 +273,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-1.jpg",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         },
@@ -284,9 +284,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-2.jpg",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         },
@@ -295,9 +295,9 @@
           "settings": {
             "button_label": "SEE MORE",
             "button_url": "booqable://root",
-            "description_deco": "",
+            "description": "",
             "image": "booqable://assets/image-columns-3.jpg",
-            "title_deco": "Extra card"
+            "title": "Extra card"
           },
           "disabled": null
         }
@@ -528,9 +528,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "Get your garden ready for the summer",
-            "image": "booqable://assets/image-article-1.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-1.jpeg"
           },
           "disabled": null
         },
@@ -540,9 +540,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "How to choose the best tools for the job",
-            "image": "booqable://assets/image-article-2.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-2.jpeg"
           },
           "disabled": null
         },
@@ -552,9 +552,9 @@
             "article_btn": "Read more",
             "article_btn_url": "booqable://root",
             "article_tag": "Category",
+            "article_text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros.",
             "heading": "Before you start, read this",
-            "image": "booqable://assets/image-article-3.jpeg",
-            "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros."
+            "image": "booqable://assets/image-article-3.jpeg"
           },
           "disabled": null
         }
@@ -613,8 +613,8 @@
           "type": "card",
           "settings": {
             "icon": "truck-fast",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "Free delivery"
+            "description": "Free delivery for all orders above $100",
+            "title": "Free delivery"
           },
           "disabled": null
         },
@@ -622,8 +622,8 @@
           "type": "card",
           "settings": {
             "icon": "comment",
-            "description_card": "Chat with us if you’ve any questions",
-            "title_card": "Top-Notch support"
+            "description": "Chat with us if you’ve any questions",
+            "title": "Top-Notch support"
           },
           "disabled": null
         },
@@ -631,8 +631,8 @@
           "type": "card",
           "settings": {
             "icon": "handshake",
-            "description_card": "Free delivery for all orders above $100",
-            "title_card": "100% Satisfaction Guarantee!"
+            "description": "Free delivery for all orders above $100",
+            "title": "100% Satisfaction Guarantee!"
           },
           "disabled": null
         },
@@ -640,8 +640,8 @@
           "type": "card",
           "settings": {
             "icon": "exclamation",
-            "description_card": "We know how to do it",
-            "title_card": "20 years of experience"
+            "description": "We know how to do it",
+            "title": "20 years of experience"
           },
           "disabled": null
         }


### PR DESCRIPTION
This PR supposed to fix previews of blocks in theme editor if it's show wrong information or information missed at all.

Before:
![image (111)](https://github.com/user-attachments/assets/0a650320-9eaa-4dc0-8a95-fc3455994c31)


After:

![Arc Sept 5 34](https://github.com/user-attachments/assets/22878f14-c3c4-4882-a22c-808f804a6bf2)
