### PR TITLE
Fix positioning of testimonial quotation marks

### DIFF
--- a/assets/testimonials.css
+++ b/assets/testimonials.css
@@ -36,6 +36,10 @@
   padding-bottom: 17px;
 }
 
+.testimonials__quote p {
+  display: inline;
+}
+
 .testimonials__cite {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This PR's goal is to fix the positioning of quotation marks in testimonials section

Before:
<img width="1609" alt="Screenshot 2024-09-10 at 16 24 19" src="https://github.com/user-attachments/assets/b6d77be7-e4c8-479b-8916-5e0fe2780949">


After:
![Arc Sept 12 26](https://github.com/user-attachments/assets/dbbefd16-90f1-4e48-a62e-67571112e5f3)

