### PR TITLE
Add center alignment for top bar info items

### DIFF
--- a/assets/top-bar.css
+++ b/assets/top-bar.css
@@ -62,6 +62,8 @@
 
   .top-bar__info-item {
     padding-left: 3vw;
+    display: flex;
+    align-items: center;
   }
 
   .top-bar__info-item:first-child {


### PR DESCRIPTION
The customer complained that after he changed the content on the Top bar, then it looked broken, so this PR aims to fix the issue

Before:

![Arc 2024-10-22 14 05 32](https://github.com/user-attachments/assets/ee002b98-2c04-4538-b8ab-f082c5b956d8)


After:

![Arc 2024-10-22 14 06 13](https://github.com/user-attachments/assets/e399ab52-0cf7-478e-ada7-1c136971c9eb)
