### PR TITLE
Update the default value to true for full-width content in the Hero section

### DIFF
--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -425,7 +425,7 @@
         "type": "checkbox",
         "id": "full_width_content",
         "label": "Full-width text content",
-        "default": false
+        "default": true
       },
       {
         "type": "image_picker",


### PR DESCRIPTION
After deploying the latest changes to production I noticed that content in the Hero section had become broken on the customer's site because the max-width content option has been automatically applied there. Therefore, the default value `true` of `full_width_content` should fix the issue