### PR TITLE
Add limit content by width option in Hero section

### DIFF
--- a/assets/hero.css
+++ b/assets/hero.css
@@ -59,6 +59,10 @@
   margin: 0 var(--margin-right-mobile) 0 var(--margin-left-mobile);
 }
 
+.hero__text-area--max-width {
+  max-width: 550px;
+}
+
 .hero__description:not(:last-child) {
   padding: 0 0 23px;
 }
@@ -67,7 +71,7 @@
   padding-bottom: 0;
 }
 
-.hero__description.bq-content p + p {
+.hero__text-area:not(.hero__text-area--max-width) .hero__description.bq-content p + p {
   margin: 0;
 }
 

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -11,6 +11,7 @@
 {%- assign height_mobile           = section.settings.height_mobile -%}
 {%- assign image                   = section.settings.image -%}
 {%- assign image_mobile            = section.settings.image_mobile -%}
+{%- assign limit_content_width     = section.settings.limit_content_width -%}
 {%- assign overlay_background      = section.settings.overlay_background -%}
 {%- assign overlay_color           = section.settings.overlay_color -%}
 {%- assign overlay_opacity         = section.settings.overlay_opacity -%}
@@ -289,7 +290,7 @@
       {%- if full_width -%}
         <div class="hero__container container">
       {%- endif -%}
-          <div class="hero__text-area{% if show_overlay %} hero__text-area--color{%- endif -%}">
+          <div class="hero__text-area{% if limit_content_width %} hero__text-area--max-width{% endif %}{% if show_overlay %} hero__text-area--color{%- endif -%}">
             <div class="hero__content">
               {%- if title != blank -%}
                 <h1 class="hero__title">{{- title -}}</h1>
@@ -419,6 +420,12 @@
         "id": "description",
         "label": "Description",
         "default": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br>Suspendisse varius enim in eros elementum tristique."
+      },
+      {
+        "type": "checkbox",
+        "id": "limit_content_width",
+        "label": "Limit content by width",
+        "default": false
       },
       {
         "type": "image_picker",

--- a/templates/achieve/index.json
+++ b/templates/achieve/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#131313",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 75,

--- a/templates/adore/index.json
+++ b/templates/adore/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/bliss/index.json
+++ b/templates/bliss/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "booqable://assets/image-hero-mobile.jpeg",
+        "limit_content_width": false,
         "overlay_background": "#F5FAFA",
         "overlay_color": "#2F4044",
         "overlay_opacity": 75,

--- a/templates/breeze/index.json
+++ b/templates/breeze/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#131313",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 40,

--- a/templates/care/index.json
+++ b/templates/care/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/create/index.json
+++ b/templates/create/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 40,

--- a/templates/crisp/index.json
+++ b/templates/crisp/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/moment/index.json
+++ b/templates/moment/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/motion/index.json
+++ b/templates/motion/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#131313",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 10,

--- a/templates/navigate/index.json
+++ b/templates/navigate/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/place/index.json
+++ b/templates/place/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 40,

--- a/templates/raw/index.json
+++ b/templates/raw/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/route/index.json
+++ b/templates/route/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 40,

--- a/templates/scenic/index.json
+++ b/templates/scenic/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 45,

--- a/templates/shine/index.json
+++ b/templates/shine/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/signature/index.json
+++ b/templates/signature/index.json
@@ -17,6 +17,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#F5FAFA",
         "overlay_color": "#2F4044",
         "overlay_opacity": 75,

--- a/templates/space/index.json
+++ b/templates/space/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.jpeg",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,

--- a/templates/spring/index.json
+++ b/templates/spring/index.json
@@ -29,6 +29,7 @@
         "height_mobile": "full",
         "image": "booqable://assets/image-hero.webp",
         "image_mobile": "",
+        "limit_content_width": false,
         "overlay_background": "#000000",
         "overlay_color": "#FFFFFF",
         "overlay_opacity": 30,


### PR DESCRIPTION
Once we had been implementing this feature but after deploying it on production there were some complaints of broken layouts in section, therefore everything was reverted. 
Now we don't use any restrictions for the Hero section's content and still it can be a bit confusing for customers to have to add line breaks to get the look they want (aligned to the left or right side of the screen).

So all previous issues were taken into account and this PR aims to add an extra max-width option to limit the width of Hero section's content as in designs

![Arc 2024-10-25 10 44 45](https://github.com/user-attachments/assets/b2759daf-ba15-4735-8209-038753074e18)


