### PR TITLE
Add the new `Text with image` section

### DIFF
--- a/assets/text-with-image.css
+++ b/assets/text-with-image.css
@@ -1,0 +1,156 @@
+.text-image__wrapper {
+  --border-width: 1px;
+  --button-margin-x: 8px;
+  --buttons-justify-content: center;
+  --content-alignment: center;
+  --content-direction: column;
+  --content-margin-x: 16px;
+  --indent-md: 24px;
+  --indent-sm: 16px;
+  --width-image: 100%;
+  --width-text-area: 100%;
+
+  overflow: hidden;
+  position: relative;
+  color: var(--color-primary);
+  background: var(--background-primary);
+}
+
+.text-image__content--padding-top {
+  padding-top: var(--padding-top-mobile);
+}
+
+.text-image__content--padding-bottom {
+  padding-bottom: var(--padding-bottom-mobile);
+}
+
+.text-image__content--with-border {
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--border-radius-block);
+}
+
+.text-image__content {
+  display: flex;
+  align-items: center;
+  flex-direction: var(--content-direction);
+  gap: var(--gap);
+  padding-left: var(--content-margin-x);
+  padding-right: var(--content-margin-x);
+}
+
+.text-image__media {
+  width: var(--width-image);
+}
+
+.text-image__image-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.text-image__image-wrapper .text-image__image {
+  border-radius: var(--border-radius-block);
+}
+
+.text-image__text-area {
+  text-align: var(--content-alignment);
+  width: var(--width-text-area);
+}
+
+.text-image__tag + .text-image__title {
+  margin-top: var(--indent-sm);
+}
+
+.text-image__description:has(+ .text-image__buttons) {
+  margin-bottom: var(--indent-md);
+}
+
+.text-image__buttons {
+  margin: 0 calc(-1 * var(--button-margin-x)) calc(-1 * var(--button-margin-bottom));
+  display: flex;
+  align-items: center;
+  justify-content: var(--buttons-justify-content);
+  flex-wrap: wrap;
+}
+
+.text-image__button {
+  margin-left: var(--button-margin-x);
+  margin-right: var(--button-margin-x);
+}
+
+.text-image__wrapper--stretch-image {
+  --indent-lg: 0;
+  --width-image: calc(100% + var(--horizontal-padding-mobile) * 2 + var(--content-margin-x) * 2);
+}
+
+.text-image__wrapper--stretch-image .text-image__media {
+  margin-left: calc(-1 * var(--horizontal-padding-mobile) + -1 * var(--content-margin-x));
+  margin-right: calc(-1 * var(--horizontal-padding-mobile) + -1 * var(--content-margin-x));
+}
+
+.text-image__wrapper--stretch-image .text-image__image-wrapper {
+  height: 100%;
+}
+
+.text-image__wrapper--stretch-image .text-image__image {
+  max-width: none;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+@media (min-width: 992px) {
+  .text-image__wrapper {
+    --buttons-justify-content: flex-start;
+    --content-alignment: left;
+    --content-direction: var(--flex-direction);
+    --content-margin-x: 32px;
+    --width-image: var(--width-image-stretched);
+    --width-text-area: calc(100% - var(--width-image-stretched));
+  }
+
+  .text-image__wrapper:has(.text-image__media:only-child) {
+    --width-image: 100%;
+    --left: 0 !important;
+    --right: 0 !important;
+  }
+
+  .text-image__wrapper:has(.text-image__text-area:only-child) {
+    --width-text-area: 100%;
+  }
+
+  .text-image__content--padding-top {
+    padding-top: var(--padding-top);
+  }
+
+  .text-image__content--padding-bottom {
+    padding-bottom: var(--padding-bottom);
+  }
+
+  .text-image__wrapper--stretch-image {
+    --content-direction: var(--flex-direction-stretched);
+    --width-image: calc(100% - var(--width-image-stretched) + var(--gap));
+  }
+
+  .text-image__wrapper--stretch-image .text-image__media {
+    position: absolute;
+    top: 0;
+    left: var(--left);
+    right: var(--right);
+    bottom: 0;
+    margin: 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  .text-image__wrapper {
+    --content-margin-x: 46px;
+    --indent-lg: 32px;
+  }
+
+  .text-image__text-area:not(:only-child),
+  .text-image__wrapper:not(.text-image__wrapper--stretch-image) .text-image__media:not(:only-child) {
+    padding: 0 var(--indent-lg);
+  }
+}

--- a/sections/text-with-image.liquid
+++ b/sections/text-with-image.liquid
@@ -1,0 +1,314 @@
+{{ "text-with-image.css" | asset_url | stylesheet_tag }}
+
+{%- assign button_primary_label   = section.settings.button_primary_label -%}
+{%- assign button_primary_url     = section.settings.button_primary_url -%}
+{%- assign button_secondary_label = section.settings.button_secondary_label -%}
+{%- assign button_secondary_url   = section.settings.button_secondary_url -%}
+{%- assign color_scheme           = section.settings.color_scheme -%}
+{%- assign description            = section.settings.description -%}
+{%- assign full_width             = section.settings.full_width -%}
+{%- assign image                  = section.settings.image -%}
+{%- assign image_position         = section.settings.image_position -%}
+{%- assign padding_bottom         = section.settings.padding_bottom -%}
+{%- assign padding_bottom_mobile  = section.settings.padding_bottom_mobile -%}
+{%- assign padding_top            = section.settings.padding_top -%}
+{%- assign padding_top_mobile     = section.settings.padding_top_mobile -%}
+{%- assign show_borders           = section.settings.show_borders -%}
+{%- assign tag                    = section.settings.tag -%}
+{%- assign title                  = section.settings.title -%}
+
+{% comment %} CSS variables start {% endcomment %}
+{%- capture variables -%}
+  {%- case padding_top -%}
+    {%- when 'small' -%}
+      --padding-top: 32px;
+    {%- when 'medium' -%}
+      --padding-top: 58px;
+    {%- when 'large' -%}
+      --padding-top: 120px;
+  {%- endcase -%}
+
+  {%- case padding_bottom -%}
+    {%- when 'small' -%}
+      --padding-bottom: 32px;
+    {%- when 'medium' -%}
+      --padding-bottom: 58px;
+    {%- when 'large' -%}
+      --padding-bottom: 120px;
+  {%- endcase -%}
+
+  {%- case padding_top_mobile -%}
+    {%- when 'small' -%}
+      --padding-top-mobile: 16px;
+    {%- when 'medium' -%}
+      --padding-top-mobile: 32px;
+    {%- when 'large' -%}
+      --padding-top-mobile: 64px;
+  {%- endcase -%}
+
+  {%- case padding_bottom_mobile -%}
+    {%- when 'small' -%}
+      --padding-bottom-mobile: 16px;
+    {%- when 'medium' -%}
+      --padding-bottom-mobile: 32px;
+    {%- when 'large' -%}
+      --padding-bottom-mobile: 64px;
+  {%- endcase -%}
+
+  {%- case image_position -%}
+    {%- when 'left' -%}
+      --flex-direction: row;
+      --flex-direction-stretched: row-reverse;
+      --gap: 32px;
+      --width-image-stretched: 53.25%;
+      --right: calc(var(--width-image-stretched) - var(--gap));
+      --left: auto;
+    {%- when 'right' -%}
+      --flex-direction: row-reverse;
+      --flex-direction-stretched: row;
+      --gap: 32px;
+      --width-image-stretched: 53.25%;
+      --right: auto;
+      --left: calc(var(--width-image-stretched) - var(--gap));
+  {%- endcase -%}
+{%- endcapture -%}
+{% comment %} CSS variables end {% endcomment %}
+
+<div class="text-image__wrapper{% if full_width %} text-image__wrapper--stretch-image{% endif %} color-{{- color_scheme.id -}}" style="{{- variables | escape -}}">
+  <div class="text-image__container container">
+    <div class="text-image__content{% if show_borders and full_width == false %} text-image__content--with-border{% endif %}{% if padding_top != blank or padding_top_mobile != blank %} text-image__content--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} text-image__content--padding-bottom{%- endif -%}">
+      {%- if image.url != blank -%}
+        <div class="text-image__media">
+          <div class="text-image__image-wrapper">
+            {%- render 'image',
+                image: image,
+                loading: 'lazy',
+                class: 'text-image__image',
+                size: 'flexible'
+            -%}
+          </div>
+        </div>
+      {%- endif -%}
+
+      {%- if tag != blank or title != blank or description != blank or button_primary_label != blank and button_primary_url != blank or button_secondary_label != blank and button_secondary_url != blank -%}
+        <div class="text-image__text-area">
+          {%- if tag != blank -%}
+            <span class="text-image__tag tagline">{{- tag -}}</span>
+          {%- endif -%}
+
+          {%- if title != blank -%}
+            <h2 class="text-image__title">{{- title -}}</h2>
+          {%- endif -%}
+
+          {%- if description != blank -%}
+            <div class="text-image__description bq-content rx-content text-medium">
+              {{- description -}}
+            </div>
+          {%- endif -%}
+
+          {%- if button_primary_label != blank and button_primary_url != blank or button_secondary_label != blank and button_secondary_url != blank -%}
+            <div class="text-image__buttons">
+              {%- if button_primary_label != blank and button_primary_url != blank -%}
+                <a class="text-image__button button button--primary button--large" href="{{ button_primary_url }}">
+                  {{- button_primary_label -}}
+                </a>
+              {%- endif -%}
+              {%- if button_secondary_label != blank and button_secondary_url != blank -%}
+                <a class="text-image__button button button--secondary" href="{{ button_secondary_url }}">
+                  {{- button_secondary_label -}}
+                  {%- render 'icon-arrow-right' -%}
+                </a>
+              {%- endif -%}
+            </div>
+          {%- endif -%}
+        </div>
+      {%- endif -%}
+    </div>
+  </div>
+</div>
+
+{% schema %}
+  {
+    "name": "Text with image",
+    "tag": "section",
+    "class": "text-image",
+    "description": "Display text with an image",
+    "blocks": [],
+    "settings": [
+      {
+        "type": "header",
+        "content": "General settings"
+      },
+      {
+        "type": "color_scheme",
+        "id": "color_scheme",
+        "label": "Color scheme",
+        "default": "set-1"
+      },
+      {
+        "type": "image_picker",
+        "id": "image",
+        "label": "Image (optional)",
+        "default": "booqable://assets/image-placeholder.png"
+      },
+      {
+        "type": "checkbox",
+        "id": "full_width",
+        "label": "Stretch the image",
+        "default": false
+      },
+      {
+        "type": "text",
+        "id": "tag",
+        "label": "Tagline",
+        "default": "TAGLINE"
+      },
+      {
+        "type": "text",
+        "id": "title",
+        "label": "Title",
+        "default": "Title"
+      },
+      {
+        "type": "contentEditor",
+        "id": "description",
+        "label": "Description",
+        "default": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique."
+      },
+      {
+        "type": "text",
+        "id": "button_primary_label",
+        "label": "Primary button label",
+        "default": "SEE MORE"
+      },
+      {
+        "type": "url",
+        "id": "button_primary_url",
+        "label": "Primary button URL",
+        "default": "booqable://root"
+      },
+      {
+        "type": "text",
+        "id": "button_secondary_label",
+        "label": "Secondary button label",
+        "default": "SEE MORE"
+      },
+      {
+        "type": "url",
+        "id": "button_secondary_url",
+        "label": "Secondary button URL",
+        "default": "booqable://root"
+      },
+      {
+        "type": "checkbox",
+        "id": "show_borders",
+        "label": "Show borders",
+        "default": true
+      },
+      {
+        "type": "header",
+        "content": "Desktop settings"
+      },
+      {
+        "type": "select",
+        "id": "image_position",
+        "label": "Layout",
+        "options": [
+          {
+            "value": "left",
+            "label": "Left"
+          },
+          {
+            "value": "right",
+            "label": "Right"
+          }
+        ],
+        "default": "left"
+      },
+      {
+        "type": "select",
+        "id": "padding_top",
+        "label": "Padding top",
+        "options": [
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      },
+      {
+        "type": "select",
+        "id": "padding_bottom",
+        "label": "Padding bottom",
+        "options": [
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "medium"
+      },
+      {
+        "type": "header",
+        "content": "Mobile settings"
+      },
+      {
+        "type": "select",
+        "id": "padding_top_mobile",
+        "label": "Padding top",
+        "options": [
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "small"
+      },
+      {
+        "type": "select",
+        "id": "padding_bottom_mobile",
+        "label": "Padding bottom",
+        "options": [
+          {
+            "value": "small",
+            "label": "Small"
+          },
+          {
+            "value": "medium",
+            "label": "Medium"
+          },
+          {
+            "value": "large",
+            "label": "Large"
+          }
+        ],
+        "default": "small"
+      }
+    ]
+  }
+{% endschema %}


### PR DESCRIPTION
We would like to add a component to be available in the Horton themes that looks like this

![Right](https://github.com/user-attachments/assets/024239e4-cdd5-474c-a37a-e691a1f9ba75)

This will allow us to make more varied pages in the previews for pages like "About us" and 'How it works" as well as giving customers more options