### PR TITLE
Add `use color scheme` option to Product card settings

### DIFF
--- a/config/settings_data.json
+++ b/config/settings_data.json
@@ -209,6 +209,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "adore": {
@@ -454,6 +455,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "bliss": {
@@ -664,6 +666,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "breeze": {
@@ -875,6 +878,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "care": {
@@ -1086,6 +1090,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "create": {
@@ -1332,6 +1337,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "crisp": {
@@ -1543,6 +1549,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "moment": {
@@ -1789,6 +1796,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "motion": {
@@ -2000,6 +2008,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "navigate": {
@@ -2246,6 +2255,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "place": {
@@ -2457,6 +2467,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "raw": {
@@ -2668,6 +2679,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "route": {
@@ -2879,6 +2891,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "scenic": {
@@ -3090,6 +3103,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "shine": {
@@ -3336,6 +3350,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "signature": {
@@ -3547,6 +3562,7 @@
       "show_card_excerpt": true,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "space": {
@@ -3793,6 +3809,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     },
     "spring": {
@@ -4003,6 +4020,7 @@
       "show_card_excerpt": false,
       "social_size": "lg",
       "social_spacing": "md",
+      "use_card_color_scheme": false,
       "use_focal_images": true
     }
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -206,6 +206,13 @@
         "default": "set-1"
       },
       {
+        "type": "checkbox",
+        "id": "use_card_color_scheme",
+        "label": "Use color scheme",
+        "default": false,
+        "info": "Use these colors instead of section ones"
+      },
+      {
         "type": "header",
         "content": "Image settings"
       },
@@ -223,7 +230,7 @@
             "label": "Contain"
           }
         ],
-        "default": "contain"
+        "default": "cover"
       },
       {
         "type": "checkbox",

--- a/snippets/product-card.liquid
+++ b/snippets/product-card.liquid
@@ -10,7 +10,8 @@
 
   {%- render 'product-card',
       product: your_id,
-      settings: settings
+      settings: settings,
+      img_size - your_id
   -%}
 
 {% endcomment %}
@@ -29,6 +30,7 @@
 {%- assign show_excerpt = settings.show_card_excerpt -%}
 {%- assign image_bg     = settings.card_image_background -%}
 {%- assign url          = "" -%}
+{%- assign use_colors   = settings.use_card_color_scheme -%}
 {%- assign use_focal    = settings.use_focal_images -%}
 
 {%- if product != blank -%}
@@ -79,7 +81,7 @@
 {%- endcapture -%}
 {% comment %} CSS variables end {% endcomment %}
 
-<div class="product-card color-{{- color_scheme.id -}}" {% if id != blank %}id="{{- id -}}"{% endif %} style="{{- card_variables | escape -}}">
+<div class="product-card{% if use_colors %} color-{{- color_scheme.id -}}{%- endif -%}" {% if id != blank %}id="{{- id -}}"{% endif %} style="{{- card_variables | escape -}}">
   <div class="product-card__vision{% if image_fit == 'contain' %}{% unless image_bg %} product-card__vision--white{% endunless %}{% endif %}{% if border %} product-card__vision--with-border{% endif %}{% unless image.url != blank %} no-image{%- endunless -%}">
     {%- if image.url != blank -%}
       {%- render 'image',


### PR DESCRIPTION
We started getting complaints from customers as expected. They said that they didn't change anything, but the colors such as highlights, text color, backgrounds have been changed on their webshop. 

It happened because yesterday we released a separate color scheme for product cards and set the default value to `color set 1` which is not suitable for some customers obviously.

So this PR aims to add a new `use color scheme` option and set its value to `false` so that colors can't affect customers' initial colors without forced enabling

![Screenshot 2024-11-19 at 15 37 14](https://github.com/user-attachments/assets/004088ac-b074-4336-8fb5-41c5121c5785)
![Screenshot 2024-11-19 at 15 37 28](https://github.com/user-attachments/assets/c210be7b-8220-4637-8fbc-cc342d2e4d91)
