### PR TITLE
Fix bug of overlapping the search bar on iPad in landscape

### DIFF
--- a/assets/adore/menu.css
+++ b/assets/adore/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/adore/quick-menu.css
+++ b/assets/adore/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/adore/search-form.css
+++ b/assets/adore/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/adore/search-form.css
+++ b/assets/adore/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/base.css
+++ b/assets/base.css
@@ -74,7 +74,8 @@ html:has(div[data-tid="Modal"][class*="Container-"]) {
   overflow: hidden;
 }
 
-.touch {
+.iphone,
+.mac {
   -webkit-text-size-adjust: 100%;
 }
 
@@ -410,7 +411,7 @@ img {
   padding: 0 var(--horizontal-padding-mobile);
 }
 
-.touch[data-orientation='landscape'] .container {
+.iphone.notch.safari[data-orientation='landscape'] .container {
   padding-left: calc(var(--padding-x-landscape) + var(--horizontal-padding-mobile));
   padding-right: calc(var(--padding-x-landscape) + var(--horizontal-padding-mobile));
 }

--- a/assets/create/menu.css
+++ b/assets/create/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/create/quick-menu.css
+++ b/assets/create/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/create/search-form.css
+++ b/assets/create/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/create/search-form.css
+++ b/assets/create/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/menu.css
+++ b/assets/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/moment/menu.css
+++ b/assets/moment/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/moment/quick-menu.css
+++ b/assets/moment/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/moment/search-form.css
+++ b/assets/moment/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/moment/search-form.css
+++ b/assets/moment/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/navigate/menu.css
+++ b/assets/navigate/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/navigate/quick-menu.css
+++ b/assets/navigate/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/navigate/search-form.css
+++ b/assets/navigate/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/navigate/search-form.css
+++ b/assets/navigate/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/search-form.css
+++ b/assets/search-form.css
@@ -191,6 +191,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/search-form.css
+++ b/assets/search-form.css
@@ -179,8 +179,14 @@
   display: block !important;
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/shine/menu.css
+++ b/assets/shine/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/shine/quick-menu.css
+++ b/assets/shine/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/shine/search-form.css
+++ b/assets/shine/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/shine/search-form.css
+++ b/assets/shine/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/space/menu.css
+++ b/assets/space/menu.css
@@ -203,7 +203,7 @@
   transition-property: var(--menu-dropdown-transition-transition-property);
 }
 
-.touch[data-orientation='landscape'] .menu__dropdown {
+.iphone.notch.safari[data-orientation='landscape'] .menu__dropdown {
   transform: translateX(calc(100% + var(--horizontal-padding-mobile) + var(--padding-x-landscape)));
 }
 

--- a/assets/space/quick-menu.css
+++ b/assets/space/quick-menu.css
@@ -26,6 +26,10 @@
   --quick-menu-opener-displaying: flex;
 }
 
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .quick-menu:has(.quick-menu__opener) {
+  --quick-menu-dropdown-right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 .quick-menu__opener {
   transition: all var(--animation-duration) var(--transition-function-ease-in-out);
   cursor: pointer;

--- a/assets/space/search-form.css
+++ b/assets/space/search-form.css
@@ -158,8 +158,14 @@
   top: calc((var(--header-height) - var(--preview-height) - var(--top-bar-height, 0px)) / 2 + var(--padding-bottom-mobile) + 8px);
 }
 
-.touch[data-orientation='landscape'] .search-form__wrapper,
-.touch[data-orientation='landscape'] .header__mobile-menu-opener-left .search-form__wrapper {
+.iphone[data-orientation="landscape"] .search-form__wrapper,
+.iphone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .search-form__wrapper,
+.android-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .search-form__wrapper,
+.windows-phone[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .search-form__wrapper,
+.other-mobile[data-orientation="landscape"] .header__mobile-menu-opener-left .search-form__wrapper {
   right: 0;
   min-width: 500px;
 }

--- a/assets/space/search-form.css
+++ b/assets/space/search-form.css
@@ -170,6 +170,20 @@
   min-width: 500px;
 }
 
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.android-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.windows-phone[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.other-mobile[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: var(--horizontal-padding-mobile);
+}
+
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .search-form__wrapper,
+.iphone.notch.safari[data-orientation="landscape"]:has(.header__menu-secondary, .header__menu-third, .header__quick-menu) .header__mobile-menu-opener-left .search-form__wrapper {
+  right: calc(var(--horizontal-padding-mobile) + var(--padding-x-landscape));
+}
+
 @media (min-width: 768px) {
   .search-form__wrapper {
     min-width: 600px;

--- a/assets/touch-device-notch.js
+++ b/assets/touch-device-notch.js
@@ -3,7 +3,7 @@ class TouchDevice {
     this.block = block;
 
     this.modifier = {
-      touch: "touch"
+      notch: "notch"
     }
 
     this.props = {
@@ -21,48 +21,101 @@ class TouchDevice {
     this.data = {
       orientation: "data-orientation"
     }
+
+    this.devices = [
+      { name: "Android Phone", regex: /Android/i },
+      { name: "Android Tablet", regex: /Android/i, exclude: /Mobile/i },
+      { name: "Chromebook", regex: /CrOS/i },
+      { name: "iPad", regex: /iPad/i },
+      { name: "iPhone", regex: /iPhone/i },
+      { name: "iPod", regex: /iPod/i },
+      { name: "Linux", regex: /Linux/i, exclude: /Android|CrOS/i },
+      { name: "Mac", regex: /Macintosh/i, exclude: /Mobile/i },
+      { name: "Other Mobile", regex: /Mobile/i },
+      { name: "Other Tablet", regex: /Tablet/i },
+      { name: "Windows PC", regex: /Windows NT/i },
+      { name: "Windows Phone", regex: /Windows Phone/i }
+    ]
+
+    this.browsers = [
+      { name: "Chrome", regex: /chrome\/([\d.]+)/i, exclude: /edg/i },
+      { name: "Edge", regex: /edg\/([\d.]+)/i },
+      { name: "Firefox", regex: /firefox\/([\d.]+)/i },
+      { name: "Internet Explorer", regex: /(?:msie |rv:)([\d.]+)/i },
+      { name: "Opera", regex: /(?:opr|opera)\/([\d.]+)/i },
+      { name: "Safari", regex: /version\/([\d.]+)/i, exclude: /chrome|crios|fxios/i }
+    ]
   }
 
   init() {
     if (!this.block) return false;
 
+    this.elements();
     this.events();
   }
 
+  elements() {
+    this.doc = document.documentElement;
+  }
+
   events() {
-    this.notchDetection();
+    this.deviceDetect();
+    this.browserDetect();
+    this.addDeviceOrientation();
 
-    window.addEventListener("resize", this.notchDetection.bind(this));
+    window.addEventListener("resize", this.addDeviceOrientation.bind(this));
   }
 
-  isTouchDevice() {
-    return (('ontouchstart' in window) ||
-       (navigator.maxTouchPoints > 0) ||
-       (navigator.msMaxTouchPoints > 0));
+  deviceDetect() {
+    const device = this.getData(this.devices)
+
+    this.addClass(device)
+    return device
   }
 
-  notchDetection() {
-    const isTouch = this.isTouchDevice();
+  browserDetect() {
+    this.addClass(this.getData(this.browsers))
+  }
 
-    if (!isTouch) return false;
+  addDeviceOrientation() {
+    if (!this.deviceDetect()) return false;
 
-    const styles = window.getComputedStyle(this.block),
-          paddingTop = parseInt(styles.getPropertyValue(this.cssVars.areaTop)),
-          paddingRight = parseInt(styles.getPropertyValue(this.cssVars.areaRight)),
-          paddingBottom = parseInt(styles.getPropertyValue(this.cssVars.areaBottom)),
-          paddingLeft = parseInt(styles.getPropertyValue(this.cssVars.areaLeft)),
-          paddings = [paddingTop, paddingRight, paddingBottom, paddingLeft],
-          hasPositive = paddings.some(value => value > 0),
-          screen = {
-            width : window.innerWidth,
-            height : window.innerHeight
-          };
+    const screen = {
+      width: window.innerWidth,
+      height: window.innerHeight
+    }
+    const hasNotch = this.checkDeviceNotch(),
+          isLandscape = screen.width > screen.height;
 
-    this.block.classList.add(this.modifier.touch);
+    this.doc.setAttribute(this.data.orientation, isLandscape ? this.props.landscape : this.props.portrait);
+    if (hasNotch) this.addClass(this.modifier.notch)
+  }
 
-    hasPositive && screen.width > screen.height
-      ? this.block.setAttribute(this.data.orientation, this.props.landscape)
-      : this.block.setAttribute(this.data.orientation, this.props.portrait)
+  checkDeviceNotch() {
+    const styles = window.getComputedStyle(this.doc),
+          paddingTop = parseInt(styles.getPropertyValue(this.cssVars.areaTop)) || 0,
+          paddingRight = parseInt(styles.getPropertyValue(this.cssVars.areaRight)) || 0,
+          paddingBottom = parseInt(styles.getPropertyValue(this.cssVars.areaBottom)) || 0,
+          paddingLeft = parseInt(styles.getPropertyValue(this.cssVars.areaLeft)) || 0;
+
+    return [paddingTop, paddingRight, paddingBottom, paddingLeft].some(value => value > 0)
+  }
+
+  addClass(name) {
+    if (!name) return false;
+
+    const sanitizedName = name.replace(/\s+/g, '-')
+
+    this.doc.classList.add(sanitizedName)
+  }
+
+  getData(arr) {
+    const userAgent = navigator.userAgent;
+    const data = arr.find(({ regex, exclude }) =>
+      regex.test(userAgent) && (!exclude || !exclude.test(userAgent))
+    )
+
+    return data?.name.toLowerCase();
   }
 }
 

--- a/assets/touch-device-notch.js
+++ b/assets/touch-device-notch.js
@@ -88,7 +88,8 @@ class TouchDevice {
           isLandscape = screen.width > screen.height;
 
     this.doc.setAttribute(this.data.orientation, isLandscape ? this.props.landscape : this.props.portrait);
-    if (hasNotch) this.addClass(this.modifier.notch)
+    if (!hasNotch) return false;
+    if (!this.doc.classList.contains(this.modifier.notch)) this.addClass(this.modifier.notch)
   }
 
   checkDeviceNotch() {


### PR DESCRIPTION
This PR is dedicated to enhance device detection and styles for mobile device compatibility

Also, after testing the Horton theme on various mobile devices and browsers in BrowserStack there are issues need to be fixed:
1. The `search bar` in the header is overlaped with the menu button on iPad in landscape device orientation
2. Position of the `search bar` and `quick menu` for theme variations that have custom header on iPhone in landscape device orientation

Before:
![Screenshot 2024-11-25 at 15 56 07](https://github.com/user-attachments/assets/fd263abd-a260-4b21-bbef-f9db84e42b18)
![Screenshot 2024-11-25 at 20 19 11](https://github.com/user-attachments/assets/cab2eb20-2932-4ae0-9b8d-71fbedab9201)
![Screenshot 2024-11-25 at 20 19 24](https://github.com/user-attachments/assets/153efa3d-4bdb-42ed-ab98-58c49a6b0ecd)


After:
![Screenshot 2024-11-25 at 16 12 58](https://github.com/user-attachments/assets/bc49c251-12c7-4df1-9d68-2c9b09b75b56)
![Screenshot 2024-11-25 at 20 21 08](https://github.com/user-attachments/assets/920acd1a-b48e-48a0-b712-c78b37a658eb)
![Screenshot 2024-11-25 at 20 20 20](https://github.com/user-attachments/assets/564b588c-7908-47e1-9f8a-0c407e45b40e)
