### PR TITLE
Add customizable translation for the button `SEE MORE` on the collections page

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -297,19 +297,16 @@ img {
   0% {
     transform: translateX(0);
   }
-  3% {
+  3.2% {
     transform: translateX(8px);
   }
-  6% {
+  5.36% {
     transform: translateX(3px);
   }
-  9% {
+  7.5% {
     transform: translateX(8px);
   }
-  12% {
-    transform: translateX(0);
-  }
-  100% {
+  11%, 100% {
     transform: translateX(0);
   }
 }
@@ -335,7 +332,7 @@ img {
 .button svg {
   margin-left: 16px;
   transform: translateX(0);
-  animation: bounce 5s var(--transition-function-ease-in-out) infinite;
+  animation: bounce 5.6s 5s var(--transition-function-ease-in-out) infinite;
 }
 
 .button path {
@@ -514,7 +511,7 @@ div[data-tid="Modal actions"] button {
   }
 
   .button:hover svg {
-    animation-play-state: paused;
+    animation: bounce 5.6s 1s var(--transition-function-ease-in-out) infinite;
   }
 
   .button--primary:hover {

--- a/sections/list-collections.liquid
+++ b/sections/list-collections.liquid
@@ -1,5 +1,6 @@
 {{ "collections.css" | asset_url | stylesheet_tag }}
 
+{%- assign button_label          = section.settings.collection_button_label -%}
 {%- assign color_scheme          = section.settings.color_scheme -%}
 {%- assign grid                  = section.settings.grid -%}
 {%- assign image_placeholder     = settings.image_placeholder -%}
@@ -102,6 +103,7 @@
       {%- paginate collections by limit -%}
         {%- if collections.size > 0 -%}
           {%- render 'collections-grid',
+              button_label: button_label,
               items: collections,
               items_type: "collections",
               placeholder: image_placeholder
@@ -131,6 +133,12 @@
         "id": "color_scheme",
         "label": "Color scheme",
         "default": "set-1"
+      },
+      {
+        "type": "text",
+        "id": "collection_button_label",
+        "label": "Button label",
+        "default": "SEE MORE"
       },
       {
         "type": "number",

--- a/snippets/collections-grid.liquid
+++ b/snippets/collections-grid.liquid
@@ -2,13 +2,15 @@
 
   This snippet is used for rendering the list of collections
 
+  button_label - "string" optional
   items - { object } *required
-  items_type - "string" *required,
+  items_type - "string" *required
   placeholder - image optional
 
   Usage:
 
   {%- render 'collections-grid',
+      button_label: "your_string",
       items: your_id,
       items_type: "your_string",
       placeholder: your_id
@@ -16,19 +18,22 @@
 
 {% endcomment %}
 
+{%- assign item_button_label = "" -%}
+
 <ul class="collections__list collection">
   {%- for item in items -%}
     {%- case items_type -%}
       {%- when "blocks" -%}
         {%- assign collection = item.settings.collection -%}
+        {%- assign item_button_label = item.settings.collection_button_label -%}
       {%- when "collections" -%}
         {%- assign collection = item -%}
+        {%- assign item_button_label = button_label -%}
     {%- endcase -%}
 
     {%- assign badge_background = item.settings.badge_background -%}
     {%- assign badge_color      = item.settings.badge_color -%}
     {%- assign badge_label      = item.settings.badge_label -%}
-    {%- assign button_label     = item.settings.collection_button_label -%}
     {%- assign button_url       = "" -%}
     {%- assign description      = "" -%}
     {%- assign id               = item.id -%}
@@ -79,7 +84,7 @@
 
           <div class="collection__buttons">
             <a class="collection__button button button--primary button--large" href="{{ button_url }}">
-              {{- button_label |  default: "SEE MORE" -}}
+              {{- item_button_label |  default: "SEE MORE" -}}
             </a>
           </div>
         </div>

--- a/templates/bliss/list-collections.json
+++ b/templates/bliss/list-collections.json
@@ -30,6 +30,7 @@
       "blocks": {},
       "block_order": [],
       "settings": {
+        "collection_button_label": "",
         "color_scheme": "set-5",
         "grid": "three",
         "limit": 6,

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -30,6 +30,7 @@
       "blocks": {},
       "block_order": [],
       "settings": {
+        "collection_button_label": "",
         "color_scheme": "set-5",
         "grid": "three",
         "limit": 6,


### PR DESCRIPTION
This PR's purpose is to fix the bug of missing translations field for the `SEE MORE` button in the theme editor on the list of collections page
And the second purpose is to adjust animations for the arrow icon in .button--secondary like on the marketing site, so that after removing hover from the button still the arrows move synchronously

![Arc 2025-01-09 18 56 01](https://github.com/user-attachments/assets/6c3b56fa-41d1-493c-ad0f-b3f1bbfee7ef)
