### PR TITLE
Add the missing rental period to the product page

### DIFF
--- a/assets/product-page.css
+++ b/assets/product-page.css
@@ -42,6 +42,10 @@
   font-weight: var(--font-weight-headers);
 }
 
+.product-main__price-separator {
+  margin: 0 5px;
+}
+
 .product-main__description {
   padding: 0 0 25px;
 }

--- a/sections/product-page.liquid
+++ b/sections/product-page.liquid
@@ -15,6 +15,7 @@
 {%- assign padding_bottom_mobile         = section.settings.padding_bottom_mobile -%}
 {%- assign padding_top                   = section.settings.padding_top -%}
 {%- assign padding_top_mobile            = section.settings.padding_top_mobile -%}
+{%- assign period                        = product | product_price_label -%}
 {%- assign price                         = product | product_price -%}
 {%- assign quantity                      = product | product_button -%}
 {%- assign show_breadcrumbs              = section.settings.show_breadcrumbs -%}
@@ -92,7 +93,16 @@
 
       <div class="product-main__info">
         <h1 class="product-main__title">{{- title -}}</h1>
-        <div class="product-main__price">{{- price -}}</div>
+        {%- if price != blank -%}
+          <div class="product-main__price">
+            {{- price -}}
+
+            {%- if period != blank -%}
+              <span class="product-main__price-separator">/</span>
+              {{- period -}}
+            {%- endif -%}
+          </div>
+        {%- endif -%}
 
         {%- if description != blank and description_placement == "top" -%}
           <div class="product-main__description bq-content rx-content">{{- description -}}</div>


### PR DESCRIPTION
The customer reported that the Horton theme doesn't show the rental period on the product page.
Therefore, this PR's purpose is to implement the rental period next to the price

Before:

![Arc 2025-01-27 13 02 47](https://github.com/user-attachments/assets/934eb96b-4a73-42a9-bc5c-0014fb0c176f)


After:

![Arc 2025-01-27 13 02 24](https://github.com/user-attachments/assets/f308c8c9-a474-4fdd-a215-08bf426a4506)
