### PR TITLE
Add a new option to switch between `legacy` and `next` date picker versions

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -433,6 +433,11 @@ img {
   }
 }
 
+section:has(.date-picker__instance--bottom) + section [class^="padding-top"] > div,
+section:has(.date-picker__instance--bottom) + section [class*="padding-top"] > div {
+  padding-top: calc(var(--date-picker-height) / 2);
+}
+
 div[data-tid="Modal"][class*="Container-"]:has([class*="DatePickerInput"] > div) [class*="DatePickerInput"] > div,
 div[data-tippy-root]:has([data-tid="Mini cart"] [class*="DetailContainer-"] > [class*="Quantity-"]) [class*="QuantityButton"]:first-child {
   border-top-left-radius: var(--border-radius-block) !important;

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,6 +3,8 @@ class Main {
     this.body = body;
 
     this.selector = {
+      datePicker: "bq-date-picker",
+      datePickerParent: ".date-picker__instance--bottom",
       image: ".focal-image"
     }
 
@@ -15,18 +17,46 @@ class Main {
       focalY: "data-focal-y"
     }
 
+    this.cssVar = {
+      datePickerHeight: '--date-picker-height'
+    }
+
     this.focalImageTimeout;
   }
 
   init() {
     if (!this.body) return false;
 
+    this.elements();
     this.events();
+  }
+
+  elements() {
+    this.datePicker = document.querySelector(this.selector.datePicker);
+    this.datePickerParent = document.querySelector(this.selector.datePickerParent);
   }
 
   events() {
     this.setLoadedClass();
     this.focalImages();
+    setTimeout(() => this.getDatePickerHeight(), 100);
+
+    window.addEventListener("resize", this.getDatePickerHeight.bind(this));
+  }
+
+  getDatePickerHeight() {
+    if (!this.datePickerParent) return false;
+
+    const datePickerHeight = parseInt(this.datePicker?.getBoundingClientRect().height);
+
+    if (datePickerHeight) this.setCssVar(this.cssVar.datePickerHeight, datePickerHeight);
+  }
+
+  setCssVar(key, val) {
+    document.documentElement.style.setProperty(
+      `${key}`,
+      `${val}px`
+    )
   }
 
   // adding class after loading content

--- a/assets/title.css
+++ b/assets/title.css
@@ -7,8 +7,9 @@
 }
 
 .title__wrapper {
-  --date-picker-translate: 50%;
+  --date-picker-extra-indent: calc(var(--padding-bottom-mobile) + var(--date-picker-height) / 2);
   --date-picker-positioning: absolute;
+  --date-picker-translate: 50%;
   --indent-x: 36px;
 
   position: relative;
@@ -22,6 +23,10 @@
 
 .title__wrapper--padding-bottom {
   padding-bottom: var(--padding-bottom-mobile);
+}
+
+.title:has(.title__wrapper > .title__date-picker-wrapper:last-child) .title__wrapper--padding-bottom {
+  padding-bottom: var(--date-picker-extra-indent);
 }
 
 .title__wrapper .title__container {
@@ -112,7 +117,8 @@
 @media (min-width: 992px) {
   .title__date-picker-wrapper {
     --date-picker-alignment: center;
-  }
+    --date-picker-extra-indent: calc(var(--padding-bottom) + var(--date-picker-height) / 2);
+}
 
   .title__wrapper--padding-top {
     padding-top: var(--padding-top);

--- a/assets/title.css
+++ b/assets/title.css
@@ -9,6 +9,7 @@
 .title__wrapper {
   --date-picker-translate: 50%;
   --date-picker-positioning: absolute;
+  --indent-x: 36px;
 
   position: relative;
   background: var(--background-primary);
@@ -30,8 +31,12 @@
 
 .title__content {
   text-align: center;
-  padding: 0 36px;
   color: var(--color-secondary);
+}
+
+.title__heading,
+.title__description {
+  padding: 0 var(--indent-x);
 }
 
 .title__content--color {
@@ -68,6 +73,10 @@
 
 .title__wrapper:has(.title__date-picker-wrapper) .title__description {
   margin-bottom: 30px;
+}
+
+.title__wrapper:has(.title__date-picker-wrapper bq-date-picker[version="next"]) .title__date-picker-wrapper {
+  padding: 0 var(--indent-x);
 }
 
 .title__wrapper .title__date-picker-wrapper {

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <meta name="theme-color" content="{%- if settings.accent_background != blank -%}{{- settings.accent_background -}}{%- else -%}{{- branding_color -}}{%- endif -%}">
+    <meta name="theme-color" content="{%- if settings.color_schemes.first.settings.background_accent != blank -%}{{- settings.color_schemes.first.settings.background_accent -}}{%- else -%}{{- branding_color -}}{%- endif -%}">
     {% comment %} Base stylesheets {% endcomment %}
     {{ "base.css" | asset_url | stylesheet_tag }}
     {{ "rx.css" | asset_url | stylesheet_tag }}

--- a/sections/date-picker.liquid
+++ b/sections/date-picker.liquid
@@ -5,6 +5,7 @@
 {%- assign padding_bottom        = section.settings.padding_bottom -%}
 {%- assign padding_top_mobile    = section.settings.padding_top_mobile -%}
 {%- assign padding_bottom_mobile = section.settings.padding_bottom_mobile -%}
+{%- assign size                  = section.settings.size -%}
 
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
@@ -50,7 +51,8 @@
   <div class="date-picker__container container{% if padding_top != blank or padding_top_mobile != blank %} date-picker__container--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} date-picker__container--padding-bottom{%- endif -%}">
     <div class="date-picker__inner date-picker">
       {%- render 'date-picker',
-          key: section.key
+          key: section.key,
+          size: size
       -%}
     </div>
   </div>
@@ -72,6 +74,22 @@
         "id": "color_scheme",
         "label": "Color scheme",
         "default": "set-1"
+      },
+      {
+        "type": "select",
+        "id": "size",
+        "label": "Size",
+        "options": [
+          {
+            "value": "short",
+            "label": "Short"
+          },
+          {
+            "value": "full",
+            "label": "Full"
+          }
+        ],
+        "default": "short"
       },
       {
         "type": "header",

--- a/sections/hero.liquid
+++ b/sections/hero.liquid
@@ -5,6 +5,7 @@
 {%- assign button_outline_label    = section.settings.button_outline_label -%}
 {%- assign button_outline_url      = section.settings.button_outline_url -%}
 {%- assign color_scheme            = section.settings.color_scheme -%}
+{%- assign datepicker_size         = section.settings.datepicker_size -%}
 {%- assign description             = section.settings.description -%}
 {%- assign full_width              = section.settings.full_width -%}
 {%- assign height                  = section.settings.height -%}
@@ -302,7 +303,10 @@
 
               {%- if show_datepicker -%}
                 <div class="hero__date-picker-wrapper">
-                  {%- render 'date-picker', key: section.key -%}
+                  {%- render 'date-picker',
+                      key: section.key,
+                      size: datepicker_size
+                  -%}
                 </div>
               {%- endif -%}
 
@@ -451,10 +455,30 @@
         "default": true
       },
       {
+        "type": "header",
+        "content": "Period picker"
+      },
+      {
         "type": "checkbox",
         "id": "show_datepicker",
         "default": true,
         "label": "Show period picker"
+      },
+      {
+        "type": "select",
+        "id": "datepicker_size",
+        "label": "Size",
+        "options": [
+          {
+            "value": "short",
+            "label": "Short"
+          },
+          {
+            "value": "full",
+            "label": "Full"
+          }
+        ],
+        "default": "short"
       },
       {
         "type": "header",

--- a/sections/title.liquid
+++ b/sections/title.liquid
@@ -4,6 +4,7 @@
 {%- assign custom_description      = section.settings.custom_description -%}
 {%- assign custom_title            = section.settings.custom_title -%}
 {%- assign datepicker_position     = section.settings.datepicker_position -%}
+{%- assign datepicker_size         = section.settings.datepicker_size -%}
 {%- assign full_width              = section.settings.full_width -%}
 {%- assign image                   = section.settings.image -%}
 {%- assign overlay_background      = section.settings.overlay_background -%}
@@ -66,9 +67,16 @@
 {%- if show_datepicker -%}
   {%- capture date_picker -%}
     <div class="title__date-picker-wrapper">
-      <div class="title__container container">
-        {%- render 'date-picker', key: section.key -%}
-      </div>
+      {%- unless datepicker_position == "in_text" -%}
+        <div class="title__container container">
+      {%- endunless -%}
+          {%- render 'date-picker',
+              key: section.key,
+              size: datepicker_size
+          -%}
+      {%- unless datepicker_position == "in_text" -%}
+        </div>
+      {%- endunless -%}
     </div>
   {%- endcapture -%}
 {%- endif -%}
@@ -170,6 +178,22 @@
         "id": "show_datepicker",
         "default": true,
         "label": "Show period picker"
+      },
+      {
+        "type": "select",
+        "id": "datepicker_size",
+        "label": "Size",
+        "options": [
+          {
+            "value": "short",
+            "label": "Short"
+          },
+          {
+            "value": "full",
+            "label": "Full"
+          }
+        ],
+        "default": "short"
       },
       {
         "type": "select",

--- a/sections/title.liquid
+++ b/sections/title.liquid
@@ -72,6 +72,7 @@
       {%- endunless -%}
           {%- render 'date-picker',
               key: section.key,
+              position: datepicker_position,
               size: datepicker_size
           -%}
       {%- unless datepicker_position == "in_text" -%}

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -3,46 +3,75 @@
   This snippet is used for rendering the Date picker
 
   key: section id *required,
-  background: "string" *required
+  size: "string" *required
 
   Usage:
 
   {%- render 'date-picker',
-      key: section.key
+      key: section.key,
+      size: your_id
   -%}
 
 {% endcomment %}
 
 {%- style -%}
-  #section-{{ key }} bq-date-picker {
-    /* Colors */
-    --date-picker-background-color: var(--background-accent);
-    --date-picker-border-color: var(--color-border);
-    --date-picker-icon-color: var(--color-accent);
-    --date-picker-text-color: var(--color-accent);
+  {%- if size == "short" -%}
+    #section-{{ key }} bq-date-picker {
+      /* Colors */
+      --date-picker-background-color: var(--background-accent);
+      --date-picker-border-color: var(--color-border);
+      --date-picker-icon-color: var(--color-accent);
+      --date-picker-text-color: var(--color-accent);
 
-    /* Sizes */
-    --date-picker-border-radius: var(--border-radius-button);
-    --date-picker-text-line-height: var(--font-height-lg);
-    --date-picker-text-size: 14px;
-    --date-picker-text-weight: var(--font-weight-semibold);
-    --date-picker-wrapper-padding: 12px 24px;
-  }
-
-  #section-{{ key }} .date-picker__component {
-    display: flex;
-    justify-content: var(--date-picker-alignment-mobile);
-  }
-
-  @media (min-width: 992px) {
-    #section-{{ key }} .date-picker__component {
-      justify-content: var(--date-picker-alignment);
+      /* Sizes */
+      --date-picker-border-radius: var(--border-radius-button);
+      --date-picker-text-line-height: var(--font-height-lg);
+      --date-picker-text-size: 14px;
+      --date-picker-text-weight: var(--font-weight-semibold);
+      --date-picker-wrapper-padding: 12px 24px;
     }
-  }
+
+    #section-{{ key }} .date-picker__component {
+      display: flex;
+      justify-content: var(--date-picker-alignment-mobile);
+    }
+
+    @media (min-width: 992px) {
+      #section-{{ key }} .date-picker__component {
+        justify-content: var(--date-picker-alignment);
+      }
+    }
+  {%- endif -%}
+
+  {%- if size == "full" -%}
+    #section-{{ key }} bq-date-picker {
+      /* Colors */
+      --date-picker-background-color: var(--background-accent);
+      --date-picker-box-shadow: 0 0 0 1px var(--color-border);
+      --date-picker-cleanstate-background-color: var(--background-accent);
+      --date-picker-cleanstate-text-color: var(--color-accent);
+      --date-picker-error-color: var(--color-red);
+      --date-picker-icon-color: var(--color-accent);
+      --date-picker-placeholder-color: var(--color-border);
+      --date-picker-section-border: 1px solid var(--color-accent-15);
+      --date-picker-text-color: var(--color-accent);
+
+      /* Sizes */
+      --date-picker-alignment: left;
+      --date-picker-border-radius: var(--border-radius-button);
+      --date-picker-cleanstate-alignment: left;
+      --date-picker-cleanstate-padding: 11px 25px;
+      --date-picker-section-padding: 25px;
+      --date-picker-text-line-height: 1.5;
+      --date-picker-text-size: 16px;
+      --date-picker-title-line-height: 1.5;
+      --date-picker-title-size: 16px;
+    }
+  {%- endif -%}
 {%- endstyle -%}
 
 <div class="date-picker__instance">
   <div class="date-picker__component">
-    <bq-date-picker version="next"></bq-date-picker>
+    <bq-date-picker {% if size == "short" %}version="next"{% endif %}></bq-date-picker>
   </div>
 </div>

--- a/snippets/date-picker.liquid
+++ b/snippets/date-picker.liquid
@@ -3,12 +3,14 @@
   This snippet is used for rendering the Date picker
 
   key: section id *required,
+  position: "string" *required
   size: "string" *required
 
   Usage:
 
   {%- render 'date-picker',
       key: section.key,
+      position: your_id,
       size: your_id
   -%}
 
@@ -70,7 +72,7 @@
   {%- endif -%}
 {%- endstyle -%}
 
-<div class="date-picker__instance">
+<div class="date-picker__instance{% if position == "bottom" %} date-picker__instance--bottom{%- endif -%}">
   <div class="date-picker__component">
     <bq-date-picker {% if size == "short" %}version="next"{% endif %}></bq-date-picker>
   </div>

--- a/snippets/root-styles.liquid
+++ b/snippets/root-styles.liquid
@@ -10,10 +10,11 @@
       --background-accent-hover:   {{ scheme.settings.background_accent | append: 'CC' }};
       --background-accent-hover-2: {{ scheme.settings.background_accent | append: "1A" }};
       --background-primary:        {{ scheme.settings.background }};
-      --background-primary-00:     {{ scheme.settings.background |  append: '00' }};
-      --background-primary-60:     {{ scheme.settings.background |  append: '99' }};
-      --background-primary-70:     {{ scheme.settings.background |  append: 'B3' }};
+      --background-primary-00:     {{ scheme.settings.background | append: '00' }};
+      --background-primary-60:     {{ scheme.settings.background | append: '99' }};
+      --background-primary-70:     {{ scheme.settings.background | append: 'B3' }};
       --color-accent:              {{ scheme.settings.color_accent }};
+      --color-accent-15:           {{ scheme.settings.color_accent | append: '26' }};
       --color-border:              {{ scheme.settings.color_primary | append: '26' }};
       --color-image-placeholder:   {{ scheme.settings.color_primary | append: '26' }};
       --color-outline:             {{ scheme.settings.color_accent_outline }};

--- a/templates/achieve/index.json
+++ b/templates/achieve/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-1",
+        "datepicker_size": "short",
         "description": "<p>Transform your home into a personal gym with top-tier fitness</p><p> equipment rentals — no long-term commitment, just results.</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/adore/index.json
+++ b/templates/adore/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Making travel easier and more affordable with convenient</p><p>baby gear rentals delivered to your destination</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/bliss/cart.json
+++ b/templates/bliss/cart.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "booqable://assets/image-title-background.png",
         "overlay_background": "#000000",

--- a/templates/bliss/collection.json
+++ b/templates/bliss/collection.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "booqable://assets/image-title-background.png",
         "overlay_background": "#000000",

--- a/templates/bliss/index.json
+++ b/templates/bliss/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Elevate your event experience with premier rentals with</p><p>tailored solutions for weddings, parties, and corporate events</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/bliss/list-collections.json
+++ b/templates/bliss/list-collections.json
@@ -10,6 +10,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "booqable://assets/image-title-background.png",
         "overlay_background": "#000000",

--- a/templates/bliss/page.json
+++ b/templates/bliss/page.json
@@ -10,6 +10,7 @@
         "custom_description": "{{ page.content }}",
         "custom_title": "{{ page.title }}",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "booqable://assets/image-title-background.png",
         "overlay_background": "#000000",

--- a/templates/bliss/product.json
+++ b/templates/bliss/product.json
@@ -10,7 +10,8 @@
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
-        "padding_top_mobile": "medium"
+        "padding_top_mobile": "medium",
+        "size": "short"
       },
       "disabled": null
     },

--- a/templates/bliss/search.json
+++ b/templates/bliss/search.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "Search",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "booqable://assets/image-title-background.png",
         "overlay_background": "#000000",

--- a/templates/breeze/index.json
+++ b/templates/breeze/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-1",
+        "datepicker_size": "short",
         "description": "<p>Modern kitchen appliances on your terms—rent, relax, and </p><p>enjoy convenience without the commitment.</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/care/index.json
+++ b/templates/care/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Reliable medical equipment rentals delivered fast—ensuring comfort</p><p> and quality care at home when you need it most.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "",
         "overlay_background": "#000000",

--- a/templates/collection.json
+++ b/templates/collection.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "",
         "overlay_background": "#000000",

--- a/templates/create/index.json
+++ b/templates/create/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-1",
+        "datepicker_size": "short",
         "description": "<p>Empowering your academic journey with easy, free access to the technology you need </p><p>— borrow laptops, tablets, cameras, and more to support your success.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/crisp/index.json
+++ b/templates/crisp/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Experience unmatched sound clarity and power, tailored specifically for </p><p>theatre productions, with our professional audio rental solutions.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/list-collections.json
+++ b/templates/list-collections.json
@@ -10,6 +10,7 @@
         "custom_description": "Lorem ipsum dolor sit amet.",
         "custom_title": "Collections",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "",
         "overlay_background": "#000000",

--- a/templates/moment/index.json
+++ b/templates/moment/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Stylish event decor for every budget – transform </p><p>your event without breaking the bank!</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/motion/index.json
+++ b/templates/motion/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Affordable Camera Rentals for Every Creative Project—</p><p>Capture Your Vision with the Best Gear, When You Need It.</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/navigate/index.json
+++ b/templates/navigate/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Indulge in a world of luxury and adventure on the open water, with our exclusive selection</p><p> of boats designed to offer you an unforgettable, first-class experience</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/page.json
+++ b/templates/page.json
@@ -10,6 +10,7 @@
         "custom_description": "{{ page.content }}",
         "custom_title": "{{ page.title }}",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "",
         "overlay_background": "#000000",

--- a/templates/place/index.json
+++ b/templates/place/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-3",
+        "datepicker_size": "short",
         "description": "<p>Safe, affordable, and high-quality scaffolding </p><p>solutions delivered to your site</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/product.json
+++ b/templates/product.json
@@ -10,7 +10,8 @@
         "padding_bottom": "medium",
         "padding_bottom_mobile": "medium",
         "padding_top": "medium",
-        "padding_top_mobile": "medium"
+        "padding_top_mobile": "medium",
+        "size": "short"
       },
       "disabled": null
     },

--- a/templates/raw/index.json
+++ b/templates/raw/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-5",
+        "datepicker_size": "short",
         "description": "<p>Transform your garden with ease – rent the right tools</p><p>for every job, without the commitment of buying</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/route/index.json
+++ b/templates/route/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Dependable trailer rentals tailored for every professional </p>\n<p>need, ensuring you’re equipped for anything.</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/scenic/index.json
+++ b/templates/scenic/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Explore more, stress less – find your perfect ride and start your next</p><p> adventure with our easy and affordable bike rentals.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/search.json
+++ b/templates/search.json
@@ -10,6 +10,7 @@
         "custom_description": "",
         "custom_title": "Search",
         "datepicker_position": "bottom",
+        "datepicker_size": "short",
         "full_width": true,
         "image": "",
         "overlay_background": "#000000",

--- a/templates/shine/index.json
+++ b/templates/shine/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Professional lighting rentals for every production – reliable equipment, </p><p>expert support, and seamless service to bring your vision to life.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/signature/index.json
+++ b/templates/signature/index.json
@@ -11,6 +11,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Rent high-end clothing and accessories for any occasion, and</p><p> enjoy effortless style with sustainable choices delivered right to your door.</p>",
         "full_width": true,
         "height": "medium",

--- a/templates/space/index.json
+++ b/templates/space/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-4",
+        "datepicker_size": "short",
         "description": "<p>Stylish furniture, flexible rentals – redesign your </p><p>space effortlessly, one room at a time.</p>",
         "full_width": false,
         "height": "medium",

--- a/templates/spring/index.json
+++ b/templates/spring/index.json
@@ -23,6 +23,7 @@
         "button_primary_label": "",
         "button_primary_url": "booqable://products/",
         "color_scheme": "set-2",
+        "datepicker_size": "short",
         "description": "<p>Transform your garden with ease – rent the right tools</p><p>for every job, without the commitment of buying</p>",
         "full_width": false,
         "height": "medium",


### PR DESCRIPTION
The customer complaints that the date picker is too small in comparison to other elements, it should be a primary focus of the rental process and would like to use the bigger date picker's version.

![Screenshot 2025-02-04 at 9 45 03 AM](https://github.com/user-attachments/assets/9f6d0122-5cf1-4811-a341-328dca763c47)


Therefore, this PR's purpose is to add an option to switch on `legacy` or `next` version of the date picker

![Arc 2025-02-11 15 27 29](https://github.com/user-attachments/assets/b2085ee9-cde2-4ad0-84c1-f804080fec67)
![Arc 2025-02-11 15 29 19](https://github.com/user-attachments/assets/0c9619ef-b00c-4a6b-b367-9a15a54db14b)
![Arc 2025-02-11 15 29 53](https://github.com/user-attachments/assets/dc5ba537-ffd8-415a-b08d-76ecd22d80b3)
![Arc 2025-02-14 14 30 02](https://github.com/user-attachments/assets/207d38c1-4a6b-431a-88e9-ebb8b92d1256)
![Arc 2025-02-14 14 28 47](https://github.com/user-attachments/assets/26ab091e-71ce-4047-9876-42d3b89b0e35)
