### PR TITLE
Add margin-bottom reset for the last heading elements in WYSIWYG editor

### DIFF
--- a/assets/rx.css
+++ b/assets/rx.css
@@ -145,6 +145,12 @@
   color: var(--color-outline);
 }
 
+.bq-content.rx-content h1:last-child,
+.bq-content.rx-content h2:last-child,
+.bq-content.rx-content h3:last-child {
+  margin-bottom: 0;
+}
+
 .bq-content.rx-content h1 {
   font-size: var(--font-size-h1);
   font-weight: var(--font-weight-h1);


### PR DESCRIPTION
Initial [issue](https://github.com/booqable/impact-theme/pull/120)