### PR TITLE
Fix the left gap of the mobile menu

### DIFF
--- a/assets/adore/menu.css
+++ b/assets/adore/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -847,6 +847,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/create/menu.css
+++ b/assets/create/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -847,6 +847,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/menu.css
+++ b/assets/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -619,6 +619,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/moment/menu.css
+++ b/assets/moment/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -847,6 +847,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/navigate/menu.css
+++ b/assets/navigate/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -847,6 +847,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/shine/menu.css
+++ b/assets/shine/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -847,6 +847,17 @@
     max-height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     height: calc(100dvh - var(--header-height, 110px) - var(--header-transform, 0px));
     transition-delay: 0s;
+  }
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
   }
 }
 

--- a/assets/space/menu.css
+++ b/assets/space/menu.css
@@ -33,7 +33,7 @@
   --menu-nav-position-top: calc(var(--header-height, 110px) - 1px);
   --menu-nav-position-top-sticky-header: calc(var(--header-height, 110px) - var(--top-bar-height, 0px) - 1px);
   --menu-nav-transform: translateX(100%);
-  --menu-nav-width: 100vw;
+  --menu-nav-width: 100%;
   --menu-nav-z-index: 1;
 }
 
@@ -347,6 +347,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {


### PR DESCRIPTION
The customer complained that the mobile menu doesn't have a gap on the left side and text is stuck to the edge of the screen. This happened after reverting to the default page scrollbar styles.
So this PR aims to fix the dropdown width if the scrollbar is always visible

Before:
![image (2)](https://github.com/user-attachments/assets/00f39458-c9c5-4865-9cd3-e302b8a21f2b)


After:
![Arc 2025-05-02 13 04 11](https://github.com/user-attachments/assets/abd14b08-bab5-4d61-9426-e7c979cab094)

