### PR TITLE
Fix the hamburger menu is not opening in Firefox

### DIFF
--- a/assets/menu.js
+++ b/assets/menu.js
@@ -176,7 +176,7 @@ class Menu {
   // closing menu by clicking outside it
   closeMenuOutside(event) {
     if (!this.menuOpener) return false;
-    if (this.lastOpenTimeStamp && this.lastOpenTimeStamp === event.timeStamp) return false;
+    if (this.lastOpenTimeStamp && (event.timeStamp - this.lastOpenTimeStamp < 10)) return false;
 
     const target = event.target,
           menuOpened = this.menuOpener.checked;


### PR DESCRIPTION
This pull request includes a small but important change to the `closeMenuOutside` method. The change improves the logic for detecting rapid successive clicks by introducing a time difference check instead of a strict equality comparison.

* [`assets/menu.js`](diffhunk://#diff-56e4c4a6bab03ca713bbeefa823d5e5aa3312a6f7c10845978f421afbc805fd6L179-R179): Updated the condition in the `closeMenuOutside` method to check if the time difference between the current event and the last open event is less than 10 milliseconds, instead of comparing the timestamps for equality.

### Before:
<img width="397" alt="Firefox 2025-05-07 12 29 55" src="https://github.com/user-attachments/assets/0cb0b4fc-99ad-4000-8711-9b92d524ffbd" />


### After:
<img width="397" alt="Firefox 2025-05-07 12 30 10" src="https://github.com/user-attachments/assets/037b5a79-01a6-4d9c-9f06-894fe9c0236a" />