### PR TITLE
Fix `Liquid error: internal` in Title section

### DIFF
--- a/assets/title.css
+++ b/assets/title.css
@@ -26,7 +26,7 @@
 }
 
 .title:has(.title__wrapper > .title__date-picker-wrapper:last-child) .title__wrapper--padding-bottom {
-  padding-bottom: var(--date-picker-extra-indent);
+  padding-bottom: var(--date-picker-extra-indent, 50px);
 }
 
 .title__wrapper .title__container {

--- a/sections/title.liquid
+++ b/sections/title.liquid
@@ -92,16 +92,33 @@
           <div class="title__content{% if show_overlay %} title__content--color{%- endif -%}">
             <div class="title__text-area">
               <h2 class="title__heading">
+                {%- assign title = "Title" -%}
+                {%- assign description = "" -%}
+
+                {%- if custom_title != blank -%}
+                  {%- assign title = custom_title -%}
+                {%- elsif collection.title != blank -%}
+                  {%- assign title = collection.title -%}
+                {%- elsif page.title != blank -%}
+                  {%- assign title = page.title -%}
+                {%- elsif cart.title != blank -%}
+                  {%- assign title = cart.title -%}
+                {%- endif -%}
+
+                {%- if custom_description != blank -%}
+                  {%- assign description = custom_description -%}
+                {%- elsif collection.description != blank -%}
+                  {%- assign description = collection.description -%}
+                {%- elsif page.content != blank -%}
+                  {%- assign description = page.content -%}
+                {%- endif -%}
+
                 {%- if section_preview -%}
-                  Title
+                  {{- title -}}
                 {%- else -%}
-                  {%- if custom_title == blank and collection.title == blank and page.title == blank and cart.title == blank -%}
-                    {%- assign custom_title = "Title" -%}
-                  {%- endif -%}
+                  {{- title -}}
 
-                  {{- custom_title | default: collection.title | default: page.title | default: cart.title -}}
-
-                  {%- if custom_title != blank and template == "search" and query != blank -%}
+                  {%- if title != blank and template == "search" and query != blank -%}
                     : {{ query }}
                   {%- endif -%}
                 {%- endif -%}
@@ -111,7 +128,7 @@
                 {%- if section_preview -%}
                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. <br>Suspendisse varius enim in eros elementum tristique.
                 {%- else -%}
-                  {{- custom_description | default: collection.description | default: page.content -}}
+                  {{- description -}}
                 {%- endif -%}
               </div>
 


### PR DESCRIPTION
This PR aims to fix the Liquid error: internal in the Title section. I'm unsure why liquid `default` filter is not working anymore here. Maybe it happened because of changes in collections on the backend because it was working properly before. I figured it out because by removing the `default: collection.title` filter everything works fine and the problem only occurs on the homepage.
So the changes include making the CSS more robust with fallback values and simplifying the logic for handling titles and descriptions in the Liquid file.

### CSS Improvements:
* [`assets/title.css`](diffhunk://#diff-d479a1821c7e1f7b1579a85bb408fe0e174c5dd2a857677b145d0b240934a8ccL29-R29): Updated the `padding-bottom` property to include a fallback value (`50px`) in case the `--date-picker-extra-indent` variable is not defined. This makes the styling more robust.

### Liquid Template Refactoring:
* [`sections/title.liquid`](diffhunk://#diff-8205b8c51e630d8599325945704307de73d8428f787f136a05c5ba9e4e6ba403L95-R121): Refactored the logic for determining the title and description by introducing separate `title` and `description` variables. This simplifies the code and ensures consistency when handling different scenarios (e.g., custom titles, collection titles, etc.).

### Links: 
https://linear.app/booqable/issue/SHOP-1660/the-title-section-displays-liquid-error-internal-on-the-homepage-only

### Before:
![Arc 2025-05-14 16 07 48](https://github.com/user-attachments/assets/ce193a16-145d-4a86-8251-10f78a2e845e)
![Arc 2025-05-14 16 05 38](https://github.com/user-attachments/assets/50940329-cfa5-41aa-85dc-83d2a3f205f2)
![Arc 2025-05-14 16 06 46](https://github.com/user-attachments/assets/2f03b46d-7427-49f4-89ca-1b3b831876a9)


### After:
![Arc 2025-05-14 15 59 11](https://github.com/user-attachments/assets/7cf4bff2-f197-48d5-a2e3-81365f499266)
![Arc 2025-05-14 16 04 57](https://github.com/user-attachments/assets/723d2b33-51a3-4224-8223-c4a393d0075c)
![Arc 2025-05-14 16 05 38](https://github.com/user-attachments/assets/50940329-cfa5-41aa-85dc-83d2a3f205f2)
![Arc 2025-05-14 16 06 46](https://github.com/user-attachments/assets/2f03b46d-7427-49f4-89ca-1b3b831876a9)