### PR TITLE
Fix cut off dropdown menu on desktop

### DIFF
--- a/assets/menu.css
+++ b/assets/menu.css
@@ -613,7 +613,7 @@
 
   .header-sticky .menu__list {
     width: var(--menu-nav-width);
-    margin-left: var(--menu-indent-right);
+    margin-left: clamp(0px, var(--menu-indent-right), var(--menu-indent-right));
   }
 
   .header-sticky #mobile-menu-opener:checked ~ .menu__nav {


### PR DESCRIPTION
The customer complained that the dropdown menu is cut off on the left side. It happens when no words in the menu button  and the logo is small.

Therefore this PR includes a tiny change to the `menu.css` file. The change updates the `margin-left` property of `.header-sticky .menu__list` to use the `clamp()` function to avoid it getting a value below 0.


### Before:
![Arc 2025-05-26 17 29 42](https://github.com/user-attachments/assets/b500c256-2b75-4e1d-b28c-73bfd83c09a4)

### After:
![Arc 2025-05-26 17 28 55](https://github.com/user-attachments/assets/d5e729bb-9c58-45c0-b656-afb11d552b67)

