### PR TITLE
Add loading app.css in footer section

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -25,6 +25,10 @@
 {%- assign link_youtube           = settings.social_youtube_link -%}
 {%- assign link_vimeo             = settings.social_vimeo_link -%}
 
+{%- if app != blank -%}
+  {{ "app.css" | asset_url | stylesheet_tag }}
+{%- endif -%}
+
 {% comment %} CSS variables start {% endcomment %}
 {%- capture variables -%}
   {%- case padding_top -%}


### PR DESCRIPTION
This PR adds missed `app.css` file to the footer, otherwise, if the customer uses any app only in the footer, it will be applied the app default styles