### PR TITLE
Fixes wrong syntax on fonts.liquid

### DIFF
--- a/snippets/fonts.liquid
+++ b/snippets/fonts.liquid
@@ -10,5 +10,5 @@
   {{- settings.font_body | font_link -}}
 {%- endif -%}
 {%- if settings.font_tagline != blank -%}
-  {{- settings.font_tagline | font_link =}}
+  {{- settings.font_tagline | font_link -}}
 {%- endif -%}


### PR DESCRIPTION
Part of https://linear.app/booqable/issue/GUA-1318/add-liquid-strict-mode-feature-flag-for-better-template-error