### PR TITLE
Also render the preview if we don't have an app block yet

### DIFF
--- a/sections/app.liquid
+++ b/sections/app.liquid
@@ -49,15 +49,15 @@
 
 <div class="app__wrapper color-{{- color_scheme.id -}}{% if padding_top != blank or padding_top_mobile != blank %} app__wrapper--padding-top{% endif %}{% if padding_bottom != blank or padding_bottom_mobile != blank %} app__wrapper--padding-bottom{%- endif -%}" style="{{- variables | escape -}}">
   <div class="app__container container">
-    {%- unless section_preview -%}
-      <div class="app__content">
-        {% render 'app', block: app, section: section %}
-      </div>
-    {%- else -%}
+    {%- if section_preview or app == nil -%}
       <div class="app__preview">
         <span>The contents of this section vary by App.</span>
       </div>
-    {%- endunless -%}
+    {%- else -%}
+      <div class="app__content">
+        {% render 'app', block: app, section: section %}
+      </div>
+    {%- endif -%}
   </div>
 </div>
 


### PR DESCRIPTION
When users add an new App section but before they choose which app to put in the section that section will have no blocks, resulting in a blank space which is a bit disorienting. This change additionally renders the preview when the user hasn't picked an app block yet.

---

Before:
<img width="1359" alt="Screenshot 2025-06-09 at 09 37 38" src="https://github.com/user-attachments/assets/5c8097f2-3165-442f-ad9c-8489b4d09126" />

After:
<img width="1358" alt="Screenshot 2025-06-09 at 09 34 59" src="https://github.com/user-attachments/assets/543bb7ad-458d-4790-9d0d-d249deac3ab9" />
