### PR TITLE
Align secondary menu dropdown items

### DIFF
--- a/assets/adore/menu.css
+++ b/assets/adore/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -347,6 +361,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {
@@ -763,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -851,17 +865,6 @@
   }
 }
 
-@media (min-width: 992px) {
-  .menu__nav * {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-  }
-
-  .menu__nav *::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
-}
-
 @media (min-width: 1200px) {
   body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }

--- a/assets/create/menu.css
+++ b/assets/create/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -347,6 +361,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {
@@ -763,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -851,17 +865,6 @@
   }
 }
 
-@media (min-width: 992px) {
-  .menu__nav * {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-  }
-
-  .menu__nav *::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
-}
-
 @media (min-width: 1200px) {
   body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }

--- a/assets/moment/menu.css
+++ b/assets/moment/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -347,6 +361,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {
@@ -763,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -851,17 +865,6 @@
   }
 }
 
-@media (min-width: 992px) {
-  .menu__nav * {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-  }
-
-  .menu__nav *::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
-}
-
 @media (min-width: 1200px) {
   body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }

--- a/assets/navigate/menu.css
+++ b/assets/navigate/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -347,6 +361,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {
@@ -763,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -851,17 +865,6 @@
   }
 }
 
-@media (min-width: 992px) {
-  .menu__nav * {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-  }
-
-  .menu__nav *::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
-}
-
 @media (min-width: 1200px) {
   body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }

--- a/assets/shine/menu.css
+++ b/assets/shine/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -347,6 +361,17 @@
 
 .menu__message:has(.menu__message-text) .icon {
   margin-right: 15px;
+}
+
+@media (min-width: 992px) {
+  .menu__nav * {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .menu__nav *::-webkit-scrollbar {
+    display: none; /* Safari and Chrome */
+  }
 }
 
 @media (min-width: 1100px) {
@@ -763,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -851,17 +865,6 @@
   }
 }
 
-@media (min-width: 992px) {
-  .menu__nav * {
-    scrollbar-width: none; /* Firefox */
-    -ms-overflow-style: none; /* IE/Edge */
-  }
-
-  .menu__nav *::-webkit-scrollbar {
-    display: none; /* Safari and Chrome */
-  }
-}
-
 @media (min-width: 1200px) {
   body:has(.menu-third) .menu-third {
     --extra-menu-item-indent: 16px;
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }

--- a/assets/space/menu.css
+++ b/assets/space/menu.css
@@ -319,7 +319,21 @@
 }
 
 .menu-secondary {
+  --menu-secondary-dropdown-padding-x: var(--horizontal-padding-mobile);
+
   display: none;
+}
+
+.menu-secondary__dropdown-list {
+  max-width: var(--max-width);
+  max-height: calc(100dvh - var(--header-height, 242px));
+  padding: 25px var(--menu-secondary-dropdown-padding-x);
+  margin: 0 auto;
+  overflow-y: auto;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  align-items: flex-start;
 }
 
 .menu-third {
@@ -774,17 +788,6 @@
     display: none;
   }
 
-  .menu-secondary__dropdown-list {
-    max-width: var(--max-width);
-    max-height: calc(100dvh - var(--header-height, 242px));
-    padding: 25px var(--horizontal-padding);
-    margin: 0 auto;
-    overflow-y: auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(235px, 1fr));
-    align-items: flex-start;
-  }
-
   .menu-secondary__dropdown-link {
     font-size: calc(var(--font-size-regular) + 4px);
     font-weight: var(--font-weight-regular);
@@ -871,8 +874,24 @@
     --menu-opener-padding: 11px 33px;
   }
 
+  .menu-secondary {
+    --menu-secondary-dropdown-padding-x: var(--horizontal-padding);
+  }
+
   .header-sticky .menu__list {
     margin-left: var(--menu-indent-left);
+  }
+}
+
+@media (max-width: 1099px) {
+  .menu__opener {
+    background: none;
+    border-color: var(--color-border);
+  }
+
+  .menu__opener:hover {
+    background: transparent;
+    border-color: var(--color-border);
   }
 }
 
@@ -902,17 +921,5 @@
   .menu-secondary__item.has-dropdown:hover .menu-secondary__dropdown-opener:has(+ .menu-secondary__link) .menu-secondary__item-icon path {
     fill: var(--color-outline);
     stroke: var(--color-outline);
-  }
-}
-
-@media (max-width: 1099px) {
-  .menu__opener {
-    background: none;
-    border-color: var(--color-border);
-  }
-
-  .menu__opener:hover {
-    background: transparent;
-    border-color: var(--color-border);
   }
 }


### PR DESCRIPTION
The customer complained that text justification for the Secondary Menu has irregular text justification. Some elements are left, center, or right justified.

This PR introduces consistent updates across several themes having header with blocks to enhance menu styling and responsiveness. The changes include significant improvements to dropdown menus. These updates aim to provide a more uniform and user-friendly experience.

### Dropdown Menu Enhancements:
* Added `--menu-secondary-dropdown-padding-x` variable for consistent horizontal padding in dropdown menus. Set the width of dropdown items to have the same width across all dropdowns of the secondary menu. (`assets/adore/menu.css` [[1]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338) `assets/create/menu.css` [[2]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338) `assets/moment/menu.css` [[3]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338) `assets/navigate/menu.css` [[4]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338) `assets/shine/menu.css` [[5]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338) `assets/space/menu.css` [[6]](diffhunk://#diff-fc3990909a7bcdac2a16bbea9fad7c4d477335750923ef76c9718d6d53a41c7eR322-R338)

### Cleanup and Consistency:
* Reordered styles to streamline the codebase.



### Before:
![Arc 2025-06-12 14 25 53](https://github.com/user-attachments/assets/36d1021b-9639-4c26-88ce-caedd0e4d30b)
![Arc 2025-06-12 14 26 04](https://github.com/user-attachments/assets/9a9dcdfb-c7e7-4f20-a198-d49a2cdf253b)
![Arc 2025-06-12 14 26 20](https://github.com/user-attachments/assets/8898e6e9-163a-4342-9ce6-0c454cbbbcc2)



### After:
![Arc 2025-06-12 14 24 33](https://github.com/user-attachments/assets/88f9e649-6b1f-400b-ba4f-0fc59cfbdd05)
![Arc 2025-06-12 14 24 57](https://github.com/user-attachments/assets/3488d464-c0af-4909-bb0c-704dd5a2c278)
![Arc 2025-06-12 14 25 07](https://github.com/user-attachments/assets/71a988bc-4d9e-4c94-95bd-792997969baf)
