### PR TITLE
Footer: Fix liquid syntax error in default installation

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -267,7 +267,7 @@
         "type": "text",
         "id": "bottom_text",
         "label": "Bottom message",
-        "default": "{{ \"now\" | date: \"%Y\" }} {{ shop.name }}. All right reserved.",
+        "default": "{{ 'now' | date: '%Y' }} {{ shop.name }}. All right reserved.",
         "info": "This template keeps the year auto-updated and returns the name of your company"
       },
       {


### PR DESCRIPTION
On a fresh install of a Horton theme you can see a liquid error in the bottom. It seems to come from this default value where `"` is escaped with a slash. That does not seem to work, so I changed the double quote to a single quote and this seems to work well.

<img width="628" height="818" alt="image - 2025-07-22T160015 941" src="https://github.com/user-attachments/assets/3c0a2d55-4ebe-4357-a5b9-11aaff99b054" />


Resolves [SC-1718](https://linear.app/booqable/issue/SC-1718/horton-theme-footer-has-syntax-issues)
