### PR TITLE
Fix flattened articles on iPhone 11

### DIFF
--- a/assets/articles.css
+++ b/assets/articles.css
@@ -28,12 +28,14 @@
   grid-template-rows: max-content 1fr;
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius-block);
-  overflow: hidden;
 }
 
 .article__image-wrapper {
   aspect-ratio: var(--image-ratio);
   position: relative;
+  overflow: clip;
+  border-top-left-radius: var(--border-radius-block);  /* fix for flattened articles */
+  border-top-right-radius: var(--border-radius-block); /* on iPhone 11 */
 }
 
 .article__image {


### PR DESCRIPTION
This PR updates the styling of article components to fix display issues on iPhone 11.
Changes were tested on a real device iPhone 11 pro max iOS 16.5

### Before:
![photo_2025-07-24 23 28 01](https://github.com/user-attachments/assets/bd33e39d-7939-4e47-867f-b433d2693569)


### After:

![photo_2025-07-24 23 28 06](https://github.com/user-attachments/assets/b5852348-e3b9-4ec5-9937-2d18cf30c943)
