### PR TITLE
Fix typo in image `alt` key

### DIFF
--- a/sections/adore/header.liquid
+++ b/sections/adore/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/create/header.liquid
+++ b/sections/create/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/header.liquid
+++ b/sections/header.liquid
@@ -86,7 +86,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/moment/header.liquid
+++ b/sections/moment/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/navigate/header.liquid
+++ b/sections/navigate/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/shine/header.liquid
+++ b/sections/shine/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',

--- a/sections/space/header.liquid
+++ b/sections/space/header.liquid
@@ -94,7 +94,7 @@
     <span class="header__logo-inner">
       {%- render 'image',
           image: logo,
-          image__alt: shop.name,
+          image_alt: shop.name,
           image_class: 'header__logo-image',
           image_size: 'logo',
           loading: 'eager',


### PR DESCRIPTION
This PR makes a small but important fix to the way the logo image is rendered in multiple header section files. The change ensures that the correct parameter name, `image_alt`, is used instead of the incorrect `image__alt`, which improves consistency and prevents potential issues with image alt text rendering.