### PR TITLE
Update sidebar menu label description for mobile devices

### DIFF
--- a/sections/collection-page.liquid
+++ b/sections/collection-page.liquid
@@ -207,7 +207,8 @@
         "type": "text",
         "id": "mobile_toggler",
         "label": "Menu toggle label",
-        "default": "Menu"
+        "default": "Menu",
+        "info": "Displayed on mobile devices only"
       },
       {
         "type": "header",


### PR DESCRIPTION
This pull request makes a minor update to the collection template by adding additional information to the `mobile_toggler` setting. The update clarifies that the menu toggle label is displayed only on mobile devices.

<img width="317" height="199" alt="Arc 2025-12-11 11 47 43" src="https://github.com/user-attachments/assets/3f9787f8-8ce2-403e-a2b5-b47c7c68f063" />
<img width="317" height="224" alt="Arc 2025-12-11 11 47 14" src="https://github.com/user-attachments/assets/15c3c830-d03c-430c-bbd7-2c603f833798" />


