### PR TITLE
Add data-block-key and data-block-name attributes to theme blocks

### DIFF
--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -13,7 +13,7 @@
   width: 100%;
   overflow: hidden;
   border-radius: var(--border-radius-block);
-  padding: 12px 0;
+  border: 1px solid var(--color-border);
 }
 
 .carousel__wrapper {
@@ -41,13 +41,10 @@
   min-width: var(--slide-width-mobile);
   max-width: var(--slide-width-mobile);
   padding: 0;
-  border-top: 1px solid var(--color-border);
-  border-bottom: 1px solid var(--color-border);
-  border-right: 1px solid var(--color-border);
 }
 
-.carousel__item:first-child {
-  border-left: 1px solid var(--color-border);
+.carousel__item .block-frame .block-frame__buttons {
+  transform: translateX(-50%) !important;
 }
 
 .carousel__navigation {

--- a/assets/carousel.css
+++ b/assets/carousel.css
@@ -13,7 +13,7 @@
   width: 100%;
   overflow: hidden;
   border-radius: var(--border-radius-block);
-  border: 1px solid var(--color-border);
+  padding: 12px 0;
 }
 
 .carousel__wrapper {
@@ -41,6 +41,13 @@
   min-width: var(--slide-width-mobile);
   max-width: var(--slide-width-mobile);
   padding: 0;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border);
+}
+
+.carousel__item:first-child {
+  border-left: 1px solid var(--color-border);
 }
 
 .carousel__navigation {

--- a/assets/collections.css
+++ b/assets/collections.css
@@ -47,7 +47,6 @@
   height: 100%;
   min-height: var(--item-min-height);
   position: relative;
-  overflow: hidden;
   border-radius: var(--border-radius-block);
 }
 

--- a/assets/columns.css
+++ b/assets/columns.css
@@ -38,7 +38,6 @@
   flex-direction: column;
   position: relative;
   text-align: var(--text-align);
-  overflow: hidden;
 }
 
 .columns__content {

--- a/assets/testimonials.css
+++ b/assets/testimonials.css
@@ -81,7 +81,6 @@
 
 .testimonials__list.carousel .testimonials__blockquote {
   border: none;
-  border-right: 1px solid var(--color-border);
   border-radius: 0;
 }
 

--- a/assets/testimonials.css
+++ b/assets/testimonials.css
@@ -81,6 +81,7 @@
 
 .testimonials__list.carousel .testimonials__blockquote {
   border: none;
+  border-right: 1px solid var(--color-border);
   border-radius: 0;
 }
 

--- a/sections/about-us.liquid
+++ b/sections/about-us.liquid
@@ -118,7 +118,7 @@
                   {%- assign icon_style = settings.icon_style -%}
 
                   {%- if text != blank or icon != "empty" -%}
-                    <div id="{{ block.id }}" class="about-us__block">
+                    <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="about-us__block">
                       {%- if icon != "empty" -%}
                         <div class="about-us__block-icon">
                           {%- render 'icon', icon: icon, style: icon_style -%}

--- a/sections/articles.liquid
+++ b/sections/articles.liquid
@@ -98,7 +98,7 @@
             {%- assign image = blank -%}
           {%- endif -%}
 
-          <div id="{{ block.id }}" class="articles__item article">
+          <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="articles__item article">
             <div class="article__image-wrapper">
               {%- if image.url != blank -%}
                 {%- render 'image',

--- a/sections/columns.liquid
+++ b/sections/columns.liquid
@@ -146,7 +146,7 @@
               {%- endif -%}
           {%- endcase -%}
 
-          <div id="{{ block.id }}" class="columns__item columns__item--{{ type }}{% if show_borders %} columns__item--with-border{% endif %}{% if show_overlay and deco %} columns__item--with-overlay{%- endif -%}">
+          <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="columns__item columns__item--{{ type }}{% if show_borders %} columns__item--with-border{% endif %}{% if show_overlay and deco %} columns__item--with-overlay{%- endif -%}">
             <div class="columns__content{% if icon != "empty" %} columns__content--icon-{{ icon_position }}{%- endif -%}">
               {%- if icon != "empty" -%}
                 <div class="columns__icon-wrapper">

--- a/sections/contact-form.liquid
+++ b/sections/contact-form.liquid
@@ -85,7 +85,7 @@
             {%- assign block_button_third_label     = block.settings.block_button_third_label -%}
             {%- assign block_button_third_url       = block.settings.block_button_third_url -%}
 
-            <div id="{{ block.id }}" class="contact-form__block">
+            <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="contact-form__block">
               {%- if heading != blank -%}
                 <h5 class="contact-form__heading">{{- heading -}}</h5>
               {%- endif -%}

--- a/sections/image-gallery.liquid
+++ b/sections/image-gallery.liquid
@@ -79,7 +79,7 @@
             {%- assign second_block_image_alt = second_block.settings.image_alt -%}
 
             <div class="image-gallery__row">
-              <div id="{{ first_block.id }}" class="image-gallery__item image-gallery__item--{{- first_block_index | plus: 1 -}}">
+              <div id="{{ first_block.id }}" data-block-key="{{ first_block.id }}" data-block-name="{{ first_block.name }}" class="image-gallery__item image-gallery__item--{{- first_block_index | plus: 1 -}}">
                 {%- render 'image',
                     image: first_block_image,
                     image_alt: first_block_image_alt,
@@ -89,7 +89,7 @@
               </div>
 
               {%- if second_block_index < size -%}
-                <div id="{{ second_block.id }}" class="image-gallery__item image-gallery__item--{{- second_block_index | plus: 1 -}}">
+                <div id="{{ second_block.id }}" data-block-key="{{ second_block.id }}" data-block-name="{{ second_block.name }}" class="image-gallery__item image-gallery__item--{{- second_block_index | plus: 1 -}}">
                   {%- render 'image',
                       image: second_block_image,
                       image_alt: second_block_image_alt,

--- a/sections/logos.liquid
+++ b/sections/logos.liquid
@@ -74,7 +74,7 @@
                 {%- assign image     = block.settings.image -%}
                 {%- assign image_alt = block.settings.image_alt -%}
 
-                <div class="logos__images-wrapper" id="{{- block.id -}}">
+                <div class="logos__images-wrapper" id="{{- block.id -}}" data-block-key="{{- block.id -}}" data-block-name="{{- block.name -}}">
                   {%- if image.url != blank -%}
                     {%- render 'image',
                       image: image,

--- a/sections/products.liquid
+++ b/sections/products.liquid
@@ -208,8 +208,10 @@
                   {% endcase %}
 
                   {%- if carousel -%}
-                    <div id="{{ item.id }}" class="carousel__item">
+                    <div id="{{ item.id }}" {% if items_type == 'blocks' %}data-block-key="{{ item.id }}" data-block-name="{{ item.name }}" {% endif %}class="carousel__item">
                       <div class="carousel__inner">
+                  {%- else -%}
+                    {% if items_type == 'blocks' %}<div data-block-key="{{ item.id }}" data-block-name="{{ item.name }}">{% endif %}
                   {%- endif -%}
                         {%- render 'product-card',
                             block_id: item.id,
@@ -219,6 +221,8 @@
                   {%- if carousel -%}
                       </div>
                     </div>
+                  {%- else -%}
+                    {% if items_type == 'blocks' %}</div>{% endif %}
                   {%- endif -%}
                 {%- endfor -%}
 

--- a/sections/testimonials.liquid
+++ b/sections/testimonials.liquid
@@ -118,12 +118,12 @@
           {%- endcapture -%}
 
           {%- if carousel -%}
-            <div id="{{ block.id }}" class="carousel__item">
+            <div id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" class="carousel__item">
               <div class="carousel__inner">
           {%- endif -%}
 
           {%- if description != blank -%}
-            <blockquote id="{{ block.id }}" class="testimonials__blockquote text-large">
+            <blockquote {% unless carousel %}id="{{ block.id }}" data-block-key="{{ block.id }}" data-block-name="{{ block.name }}" {% endunless %}class="testimonials__blockquote text-large">
               {%- if show_stars == "above" -%}
                 {{- stars_rendering -}}
               {%- endif -%}

--- a/sections/text-with-image.liquid
+++ b/sections/text-with-image.liquid
@@ -134,7 +134,6 @@
     "tag": "section",
     "class": "text-image",
     "description": "Display text with an image",
-    "blocks": [],
     "settings": [
       {
         "type": "header",

--- a/snippets/collections-grid.liquid
+++ b/snippets/collections-grid.liquid
@@ -82,7 +82,7 @@
     {%- endif -%}
     {% comment %} CSS variables end {% endcomment %}
 
-    <li class="collection__item" id="{{- id -}}"{% if badge_label != blank %} style="{{ variables | escape }}"{%- endif -%}>
+    <li class="collection__item" id="{{- id -}}"{% if items_type == "blocks" %} data-block-key="{{- id -}}" data-block-name="{{- item.name -}}"{% endif %}{% if badge_label != blank %} style="{{ variables | escape }}"{%- endif -%}>
       <div class="collection__content">
         {%- if badge_label != blank -%}
           <span class="collection__badge">{{- badge_label -}}</span>


### PR DESCRIPTION
This change adds `data-block-key` and `data-block-name` attributes to all block elements in the theme to enable better block identification and manipulation in the editor. The attributes are added to the root HTML element of each block in sections that use the blocks pattern, including carousel and grid layouts.

Static sections (header/footer) and sections where blocks are only used for configuration (search/collection-page) are correctly excluded. Conditional logic ensures attributes are only added when rendering actual block content, not collection items.

[Actions on preview blocks](https://linear.app/booqable/issue/SC-2160/actions-on-preview-blocks)